### PR TITLE
Don't mask frames from server to clients

### DIFF
--- a/src/Network/WebSockets/Monad.hs
+++ b/src/Network/WebSockets/Monad.hs
@@ -32,7 +32,6 @@ import Control.Monad (forever)
 import Control.Monad.Reader (ReaderT, ask, runReaderT)
 import Control.Monad.Trans (MonadIO, lift, liftIO)
 import Data.Foldable (forM_)
-import System.Random (newStdGen)
 
 import Blaze.ByteString.Builder (Builder)
 import Data.ByteString (ByteString)
@@ -141,8 +140,7 @@ runWebSocketsWith' :: Protocol p
                    -> Iteratee ByteString IO a
 runWebSocketsWith' opts proto ws outIter = do
     -- Create sink with a random source
-    gen <- liftIO newStdGen
-    let sinkIter = encodeMessages proto gen =$ builderToByteString =$ outIter
+    let sinkIter = encodeMessages proto =$ builderToByteString =$ outIter
     sink <- Sink <$> liftIO (newMVar sinkIter)
 
     let sender = makeBuilderSender outIter

--- a/src/Network/WebSockets/Protocol.hs
+++ b/src/Network/WebSockets/Protocol.hs
@@ -12,7 +12,6 @@ module Network.WebSockets.Protocol
     ) where
 
 import Blaze.ByteString.Builder (Builder)
-import System.Random (RandomGen)
 import qualified Data.ByteString as B
 import qualified Data.Enumerator as E
 
@@ -39,9 +38,8 @@ class Protocol p where
 
     -- | Encodes messages to binary 'Builder's. Takes a random source so it is
     -- able to do masking of frames (needed in some cases).
-    encodeMessages  :: (Monad m, RandomGen g)
+    encodeMessages  :: Monad m
                     => p
-                    -> g
                     -> E.Enumeratee (Message p) Builder m a
 
     -- | Decodes messages from binary 'B.ByteString's.

--- a/src/Network/WebSockets/Protocol/Hybi00.hs
+++ b/src/Network/WebSockets/Protocol/Hybi00.hs
@@ -17,7 +17,7 @@ instance Protocol Hybi00 where
     version        (Hybi00 p)   = version p
     headerVersions (Hybi00 p)   = headerVersions p
     supported      (Hybi00 p) h = supported p h
-    encodeMessages (Hybi00 p) g = (EL.map castMessage =$) . encodeMessages p g
+    encodeMessages (Hybi00 p)   = (EL.map castMessage =$) . encodeMessages p
     decodeMessages (Hybi00 p)   = (decodeMessages p =$) . EL.map castMessage
     finishRequest  (Hybi00 p)   = finishRequest p
     implementations             = [Hybi00 Hybi10_, Hybi00 Hybi00_]

--- a/src/Network/WebSockets/Protocol/Hybi00/Internal.hs
+++ b/src/Network/WebSockets/Protocol/Hybi00/Internal.hs
@@ -30,7 +30,7 @@ instance Protocol Hybi00_ where
     version         Hybi00_   = "hybi00"
     headerVersions  Hybi00_   = []  -- The client will elide it
     supported       Hybi00_ h = getSecWebSocketVersion h == Nothing
-    encodeMessages  Hybi00_ _ = EL.map encodeMessage
+    encodeMessages  Hybi00_   = EL.map encodeMessage
     decodeMessages  Hybi00_   = E.sequence (A.iterParser parseMessage)
     finishRequest   Hybi00_   = handshakeHybi00
     implementations           = [Hybi00_]

--- a/src/Network/WebSockets/Protocol/Hybi10.hs
+++ b/src/Network/WebSockets/Protocol/Hybi10.hs
@@ -15,7 +15,7 @@ instance Protocol Hybi10 where
     version        (Hybi10 p)   = version p
     headerVersions (Hybi10 p)   = headerVersions p
     supported      (Hybi10 p) h = supported p h
-    encodeMessages (Hybi10 p) g = (EL.map castMessage =$) . encodeMessages p g
+    encodeMessages (Hybi10 p)   = (EL.map castMessage =$) . encodeMessages p
     decodeMessages (Hybi10 p)   = (decodeMessages p =$) . EL.map castMessage
     finishRequest  (Hybi10 p)   = finishRequest p
     implementations             = [Hybi10 Hybi10_]

--- a/src/Network/WebSockets/Protocol/Hybi10/Mask.hs
+++ b/src/Network/WebSockets/Protocol/Hybi10/Mask.hs
@@ -3,11 +3,9 @@
 module Network.WebSockets.Protocol.Hybi10.Mask
     ( Mask
     , maskPayload
-    , randomMask
     ) where
 
-import Data.Bits (shiftR, xor)
-import System.Random (RandomGen, random)
+import Data.Bits (xor)
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
@@ -24,13 +22,3 @@ maskPayload (Just mask) = snd . BL.mapAccumL f 0
     f !i !c = let i' = (i + 1) `mod` len
                   m = mask `B.index` i
               in (i', m `xor` c)
-
--- | Create a random mask
-randomMask :: forall g. RandomGen g => g -> (Mask, g)
-randomMask gen = (Just (B.pack [b1, b2, b3, b4]), gen')
-  where
-    (!int, !gen') = random gen :: (Int, g)
-    !b1           = fromIntegral $ int `mod` 0x100
-    !b2           = fromIntegral $ int `shiftR` 8  `mod` 0x100
-    !b3           = fromIntegral $ int `shiftR` 16 `mod` 0x100
-    !b4           = fromIntegral $ int `shiftR` 24 `mod` 0x100


### PR DESCRIPTION
According to [RFC 6455, section 5.1](http://tools.ietf.org/html/rfc6455#section-5.1).

It fixes websockets in last Chrome build — 19.0.1084.1 dev.

[WebKit commit](http://trac.webkit.org/changeset/111829).
