### PR TITLE
Looser deps

### DIFF
--- a/websockets.cabal
+++ b/websockets.cabal
@@ -94,9 +94,9 @@ Test-suite websockets-tests
   Build-depends:
     HUnit                      >= 1.2 && < 1.3,
     QuickCheck                 >= 2.4 && < 2.6,
-    test-framework             >= 0.4 && < 0.7,
-    test-framework-hunit       >= 0.2 && < 0.3,
-    test-framework-quickcheck2 >= 0.2 && < 0.3,
+    test-framework             >= 0.4 && < 0.8,
+    test-framework-hunit       >= 0.2 && < 0.4,
+    test-framework-quickcheck2 >= 0.2 && < 0.4,
     -- Copied from regular dependencies...
     attoparsec               >= 0.9    && < 0.11,
     attoparsec-enumerator    >= 0.2    && < 0.4,


### PR DESCRIPTION
bumps the upper bounds on SHA and test-framework\* packages.
