### PR TITLE
runClientWithStream

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -125,6 +125,7 @@ module Network.WebSockets
     , runClient
     , runClientWith
     , runClientWithSocket
+    , runClientWithStream
     ) where
 
 


### PR DESCRIPTION
This patch adds runClientWithStream which is like runClientWithSocket except it allows the user to pass in a Stream. This makes it easy to add SSL for e.g. with the openssl-streams package:

``` haskell
-- import System.IO.Streams.SSL (connect)
SSL.withOpenSSL $ do
  ctx <- SSL.context
  SSL.contextSetVerificationMode ctx SSL.VerifyNone
  (i, o, ssl) <- connect ctx host (fromInteger (read port))
  WS.runClientWithStream (i, o) host path Nothing Nothing app
```
