### PR TITLE
exports Network.Websockets.Server.runServerWith

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -46,6 +46,7 @@ module Network.WebSockets
       -- * Running a standalone server
     , ServerApp
     , runServer
+    , runServerWith
 
       -- * Running a client
     , ClientApp


### PR DESCRIPTION
This patch re-exports `Network.Websockets.Server.runServerWith`.
Issue: #46

p.s. This is my first pull-request, please correct me if I'm doing anything bad or wrong > <
