### PR TITLE
Add support for subprotocols

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -4,7 +4,9 @@ module Network.WebSockets
     ( -- * Incoming connections and handshaking
       PendingConnection
     , pendingRequest
+    , AcceptRequest(..)
     , acceptRequest
+    , acceptRequestWith
     , rejectRequest
 
       -- * Main connection type
@@ -29,6 +31,7 @@ module Network.WebSockets
     , Headers
     , Request (..)
     , RequestHead (..)
+    , getRequestSubprotocols
     , Response (..)
     , ResponseHead (..)
 

--- a/src/Network/WebSockets/Http.hs
+++ b/src/Network/WebSockets/Http.hs
@@ -25,6 +25,7 @@ module Network.WebSockets.Http
     , getRequestHeader
     , getResponseHeader
     , getRequestSecWebSocketVersion
+    , getRequestSubprotocols
     ) where
 
 
@@ -231,6 +232,17 @@ getResponseHeader rsp key = case lookup key (responseHeaders rsp) of
 getRequestSecWebSocketVersion :: RequestHead -> Maybe B.ByteString
 getRequestSecWebSocketVersion p =
     lookup "Sec-WebSocket-Version" (requestHeaders p)
+
+
+--------------------------------------------------------------------------------
+-- | List of subprotocols specified by the client, in order of preference.
+-- If the client did not specify a list of subprotocols, this will be the
+-- empty list.
+getRequestSubprotocols :: RequestHead -> [B.ByteString]
+getRequestSubprotocols rh = maybe [] parse mproto
+    where
+        mproto = lookup "Sec-WebSocket-Protocol" $ requestHeaders rh
+        parse = filter (not . B.null) . BC.splitWith (\o -> o == ',' || o == ' ')
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/WebSockets/Hybi13.hs
+++ b/src/Network/WebSockets/Hybi13.hs
@@ -54,12 +54,13 @@ headerVersions = ["13"]
 
 --------------------------------------------------------------------------------
 finishRequest :: RequestHead
+              -> Headers
               -> Response
-finishRequest reqHttp =
+finishRequest reqHttp headers =
     let !key     = getRequestHeader reqHttp "Sec-WebSocket-Key"
         !hash    = hashKey key
         !encoded = B64.encode hash
-    in response101 [("Sec-WebSocket-Accept", encoded)] ""
+    in response101 (("Sec-WebSocket-Accept", encoded):headers) ""
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/WebSockets/Protocol.hs
+++ b/src/Network/WebSockets/Protocol.hs
@@ -57,7 +57,7 @@ compatible protocol req = case getRequestSecWebSocketVersion req of
 
 
 --------------------------------------------------------------------------------
-finishRequest :: Protocol -> RequestHead -> Response
+finishRequest :: Protocol -> RequestHead -> Headers -> Response
 finishRequest Hybi13 = Hybi13.finishRequest
 
 

--- a/tests/haskell/Network/WebSockets/Server/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Server/Tests.hs
@@ -25,6 +25,7 @@ import           Test.Framework.Providers.HUnit (testCase)
 import           Test.HUnit                     (Assertion, assert, (@=?))
 import           Test.QuickCheck                (Arbitrary, arbitrary)
 import           Test.QuickCheck.Gen            (Gen (..))
+import           Test.QuickCheck.Random         (newQCGen)
 
 
 --------------------------------------------------------------------------------
@@ -78,7 +79,7 @@ testOnPong = withEchoServer 42941 $ do
 --------------------------------------------------------------------------------
 sample :: Arbitrary a => IO [a]
 sample = do
-    gen <- newStdGen
+    gen <- newQCGen
     return $ (unGen arbitrary) gen 512
 
 

--- a/tests/javascript/client.js
+++ b/tests/javascript/client.js
@@ -2,13 +2,17 @@
 * Utilities                                                                    *
 *******************************************************************************/
 
-function createWebSocket(path) {
+function createWebSocket(path, subproto) {
     var host = window.location.hostname;
     if(host == '') host = 'localhost';
     var uri = 'ws://' + host + ':8000' + path;
 
     var Socket = "MozWebSocket" in window ? MozWebSocket : WebSocket;
-    return new Socket(uri);
+    if (subproto) {
+        return new Socket(uri, subproto);
+    } else {
+        return new Socket(uri);
+    }
 }
 
 
@@ -76,5 +80,25 @@ asyncTest('blob', function() {
     ws.onmessage = function(event){
         console.log(event.data)
         console.log(event.data.type)
+    };
+});
+
+asyncTest('subprotocol', function() {
+    var ws = createWebSocket("/subprotocol", ["abc", "def"]);
+
+    ws.onopen = function() {
+        ws.send("Foo");
+    };
+
+    ws.onmessage = function(event) {
+        var message = event.data;
+        equal(message, "Foo");
+        ws.close(4711, "Bar");
+    };
+
+    ws.onclose = function(event) {
+        equal(event.code, 4711);
+        equal(event.reason, "Bar");
+        start();
     };
 });


### PR DESCRIPTION
The main change from the previous pull request is to make the function loading the subprotocols from the request operate on RequestHead instead of PendingConnection. This makes it easier to integrate this into yesod-websockets and also actually makes more sense because it now matches the similar function loading the version.

Note that the javascript tests only pass if you also merge in the commit with the new close message handling.
