### PR TITLE
Handle close control messages properly

### DIFF
--- a/src/Network/WebSockets/Client.hs
+++ b/src/Network/WebSockets/Client.hs
@@ -14,6 +14,7 @@ module Network.WebSockets.Client
 import qualified Blaze.ByteString.Builder      as Builder
 import           Control.Exception             (finally)
 import qualified Data.ByteString               as B
+import           Data.IORef                    (newIORef)
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as T
 import qualified Network.Socket                as S
@@ -96,12 +97,14 @@ runClientWithStream (sIn, sOut) host path opts customHeaders app = do
     Response _ _ <- return $ finishResponse protocol request response
     mIn          <- decodeMessages protocol sIn
     mOut         <- encodeMessages protocol ClientConnection bOut
+    sentRef      <- newIORef False
     app Connection
-        { connectionOptions  = opts
-        , connectionType     = ClientConnection
-        , connectionProtocol = protocol
-        , connectionIn       = mIn
-        , connectionOut      = mOut
+        { connectionOptions   = opts
+        , connectionType      = ClientConnection
+        , connectionProtocol  = protocol
+        , connectionIn        = mIn
+        , connectionOut       = mOut
+        , connectionSentClose = sentRef
         }
   where
     protocol = defaultProtocol  -- TODO

--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -18,6 +18,7 @@ module Network.WebSockets.Connection
     , sendTextData
     , sendBinaryData
     , sendClose
+    , sendCloseCode
     , sendPing
     ) where
 
@@ -26,8 +27,11 @@ module Network.WebSockets.Connection
 import           Blaze.ByteString.Builder    (Builder)
 import qualified Blaze.ByteString.Builder    as Builder
 import           Control.Exception           (throw)
+import           Control.Monad               (unless)
 import qualified Data.ByteString             as B
 import           Data.List                   (find)
+import           Data.IORef                  (IORef, newIORef, readIORef, writeIORef)
+import           Data.Word                   (Word16)
 import           System.IO.Streams           (InputStream, OutputStream)
 import qualified System.IO.Streams           as Streams
 
@@ -75,12 +79,14 @@ acceptRequest pc = case find (flip compatible request) protocols of
         sendResponse pc response
         msgIn  <- decodeMessages protocol (pendingIn pc)
         msgOut <- encodeMessages protocol ServerConnection (pendingOut pc)
+        sentRef <- newIORef False
         let connection = Connection
-                { connectionOptions  = pendingOptions pc
-                , connectionType     = ServerConnection
-                , connectionProtocol = protocol
-                , connectionIn       = msgIn
-                , connectionOut      = msgOut
+                { connectionOptions   = pendingOptions pc
+                , connectionType      = ServerConnection
+                , connectionProtocol  = protocol
+                , connectionIn        = msgIn
+                , connectionOut       = msgOut
+                , connectionSentClose = sentRef
                 }
 
         pendingOnAccept pc connection
@@ -103,6 +109,12 @@ data Connection = Connection
     , connectionProtocol :: Protocol
     , connectionIn       :: InputStream Message
     , connectionOut      :: OutputStream Message
+    , connectionSentClose :: IORef Bool
+    -- ^ According to the RFC, both the client and the server MUST send
+    -- a close control message to each other.  Either party can initiate
+    -- the first close message but then the other party must respond.  Finally,
+    -- the server is in charge of closing the TCP connection.  This IORef tracks
+    -- if we have sent a close message and are waiting for the peer to respond.
     }
 
 
@@ -130,13 +142,25 @@ receive conn = do
 
 --------------------------------------------------------------------------------
 -- | Receive an application message. Automatically respond to control messages.
+--
+-- When the peer sends a close control message, an exception of type 'CloseRequest'
+-- is thrown.  The peer can send a close control message either to initiate a
+-- close or in response to a close message we have sent to the peer.  In either
+-- case the 'CloseRequest' exception will be thrown.  The RFC specifies that
+-- the server is responsible for closing the TCP connection, which should happen
+-- after receiving the 'CloseRequest' exception from this function.
+--
+-- This will throw 'ConnectionClosed' if the TCP connection dies unexpectedly.
 receiveDataMessage :: Connection -> IO DataMessage
 receiveDataMessage conn = do
     msg <- receive conn
     case msg of
         DataMessage am    -> return am
         ControlMessage cm -> case cm of
-            Close _   -> throw ConnectionClosed
+            Close i closeMsg -> do
+                hasSentClose <- readIORef $ connectionSentClose conn
+                unless hasSentClose $ send conn msg
+                throw $ CloseRequest i closeMsg
             Pong _    -> do
                 connectionOnPong (connectionOptions conn)
                 receiveDataMessage conn
@@ -157,7 +181,11 @@ receiveData conn = do
 
 --------------------------------------------------------------------------------
 send :: Connection -> Message -> IO ()
-send conn msg = Streams.write (Just msg) (connectionOut conn)
+send conn msg = do
+    case msg of
+        (ControlMessage (Close _ _)) -> writeIORef (connectionSentClose conn) True
+        _ -> return ()
+    Streams.write (Just msg) (connectionOut conn)
 
 
 --------------------------------------------------------------------------------
@@ -179,9 +207,23 @@ sendBinaryData conn = sendDataMessage conn . Binary . toLazyByteString
 
 
 --------------------------------------------------------------------------------
--- | Send a friendly close message
+-- | Send a friendly close message.  Note that after sending this message,
+-- you should still continue calling 'receiveDataMessage' to process any
+-- in-flight messages.  The peer will eventually respond with a close control
+-- message of its own which will cause 'receiveDataMessage' to throw the
+-- 'CloseRequest' exception.  This exception is when you can finally consider
+-- the connection closed.
 sendClose :: WebSocketsData a => Connection -> a -> IO ()
-sendClose conn = send conn . ControlMessage . Close . toLazyByteString
+sendClose conn = sendCloseCode conn 1000
+
+
+--------------------------------------------------------------------------------
+-- | Send a friendly close message and close code.  Similar to 'sendClose', you should
+-- continue calling 'receiveDataMessage' until you receive a 'CloseRequest' exception.
+-- See <http://tools.ietf.org/html/rfc6455#section-7.4> for a list of close
+-- codes.
+sendCloseCode :: WebSocketsData a => Connection -> Word16 -> a -> IO ()
+sendCloseCode conn code = send conn . ControlMessage . Close code . toLazyByteString
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/WebSockets/Hybi13.hs
+++ b/src/Network/WebSockets/Hybi13.hs
@@ -23,6 +23,7 @@ import           Data.Attoparsec                       (anyWord8)
 import qualified Data.Attoparsec                       as A
 import           Data.Binary.Get                       (getWord16be,
                                                         getWord64be, runGet)
+import           Data.Binary.Put                       (runPut, putWord16be)
 import           Data.Bits                             ((.&.), (.|.))
 import           Data.ByteString                       (ByteString)
 import qualified Data.ByteString.Base64                as B64
@@ -94,11 +95,11 @@ encodeMessage conType gen msg = (gen', builder `mappend` B.flush)
         ServerConnection -> (Nothing, gen)
         ClientConnection -> randomMask gen
     builder      = encodeFrame mask $ case msg of
-        (ControlMessage (Close pl)) -> mkFrame CloseFrame  pl
-        (ControlMessage (Ping pl))  -> mkFrame PingFrame   pl
-        (ControlMessage (Pong pl))  -> mkFrame PongFrame   pl
-        (DataMessage (Text pl))     -> mkFrame TextFrame   pl
-        (DataMessage (Binary pl))   -> mkFrame BinaryFrame pl
+        (ControlMessage (Close code pl)) -> mkFrame CloseFrame (runPut (putWord16be code) `mappend` pl)
+        (ControlMessage (Ping pl))       -> mkFrame PingFrame   pl
+        (ControlMessage (Pong pl))       -> mkFrame PongFrame   pl
+        (DataMessage (Text pl))          -> mkFrame TextFrame   pl
+        (DataMessage (Binary pl))        -> mkFrame BinaryFrame pl
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/WebSockets/Hybi13/Demultiplex.hs
+++ b/src/Network/WebSockets/Hybi13/Demultiplex.hs
@@ -1,6 +1,6 @@
 --------------------------------------------------------------------------------
 -- | Demultiplexing of frames into messages
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, OverloadedStrings #-}
 module Network.WebSockets.Hybi13.Demultiplex
     ( FrameType (..)
     , Frame (..)
@@ -14,6 +14,7 @@ module Network.WebSockets.Hybi13.Demultiplex
 import           Blaze.ByteString.Builder (Builder)
 import qualified Blaze.ByteString.Builder as B
 import           Control.Exception        (Exception, throw)
+import           Data.Binary.Get          (runGet, getWord16be)
 import qualified Data.ByteString.Lazy     as BL
 import           Data.Monoid              (mappend)
 import           Data.Typeable            (Typeable)
@@ -75,7 +76,7 @@ demultiplex :: DemultiplexState
             -> (Maybe Message, DemultiplexState)
 demultiplex state (Frame fin _ _ _ tp pl) = case tp of
     -- Return control messages immediately, they have no influence on the state
-    CloseFrame  -> (Just (ControlMessage (Close pl)), state)
+    CloseFrame  -> (Just (ControlMessage (uncurry Close parsedClose)), state)
     PingFrame   -> (Just (ControlMessage (Ping pl)), state)
     PongFrame   -> (Just (ControlMessage (Pong pl)), state)
     -- If we're dealing with a continuation...
@@ -103,3 +104,7 @@ demultiplex state (Frame fin _ _ _ tp pl) = case tp of
   where
     e = emptyDemultiplexState
     plb = B.fromLazyByteString pl
+    parsedClose =
+        if BL.null pl
+            then (1000, "")
+            else (runGet getWord16be pl, BL.drop 2 pl)

--- a/tests/haskell/Network/WebSockets/Server/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Server/Tests.hs
@@ -10,11 +10,10 @@ module Network.WebSockets.Server.Tests
 import           Control.Applicative            ((<$>))
 import           Control.Concurrent             (forkIO, killThread,
                                                  threadDelay)
-import           Control.Exception              (SomeException, handle)
-import           Control.Monad                  (forM_, forever, replicateM)
-import           Data.IORef                     (newIORef, readIORef,
-                                                 writeIORef)
-
+import           Control.Exception              (SomeException, handle, catch)
+import           Control.Monad                  (forM_, forever, replicateM, unless)
+import           Data.IORef                     (newIORef, readIORef, IORef,
+                                                 writeIORef) 
 
 --------------------------------------------------------------------------------
 import qualified Data.ByteString.Lazy           as BL
@@ -29,6 +28,7 @@ import           Test.QuickCheck.Gen            (Gen (..))
 
 --------------------------------------------------------------------------------
 import           Network.WebSockets
+import           Network.WebSockets.Connection
 import           Network.WebSockets.Tests.Util
 
 
@@ -42,7 +42,7 @@ tests = testGroup "Network.WebSockets.Server.Tests"
 
 --------------------------------------------------------------------------------
 testSimpleServerClient :: Assertion
-testSimpleServerClient = withEchoServer 42940 $ do
+testSimpleServerClient = withEchoServer 42940 "Bye" $ do
     texts  <- map unArbitraryUtf8 <$> sample
     texts' <- retry $ runClient "127.0.0.1" 42940 "/chat" $ client texts
     texts @=? texts'
@@ -52,12 +52,13 @@ testSimpleServerClient = withEchoServer 42940 $ do
         forM_ texts (sendTextData conn)
         texts' <- replicateM (length texts) (receiveData conn)
         sendClose conn ("Bye" :: BL.ByteString)
+        expectCloseException conn "Bye"
         return texts'
 
 
 --------------------------------------------------------------------------------
 testOnPong :: Assertion
-testOnPong = withEchoServer 42941 $ do
+testOnPong = withEchoServer 42941 "Bye" $ do
     gotPong <- newIORef False
     let opts = defaultConnectionOptions
                    { connectionOnPong = writeIORef gotPong True
@@ -72,6 +73,8 @@ testOnPong = withEchoServer 42941 $ do
         sendPing conn ("What's a fish without an eye?" :: Text)
         sendTextData conn ("A fsh!" :: Text)
         msg <- receiveData conn
+        sendCloseCode conn 1000 ("Bye" :: BL.ByteString)
+        expectCloseException conn "Bye"
         return $ "A fsh!" == (msg :: Text)
 
 
@@ -101,13 +104,16 @@ retry action = (\(_ :: SomeException) -> waitSome >> action) `handle` action
 
 
 --------------------------------------------------------------------------------
-withEchoServer :: Int -> IO a -> IO a
-withEchoServer port action = do
-    serverThread <- forkIO $ retry $ runServer "0.0.0.0" port server
+withEchoServer :: Int -> BL.ByteString -> IO a -> IO a
+withEchoServer port expectedClose action = do
+    cRef <- newIORef False
+    serverThread <- forkIO $ retry $ runServer "0.0.0.0" port (\c -> server c `catch` handleClose cRef)
     waitSome
     result <- action
     waitSome
     killThread serverThread
+    closeCalled <- readIORef cRef
+    unless closeCalled $ error "Expecting the CloseRequest exception"
     return result
   where
     server :: ServerApp
@@ -116,3 +122,21 @@ withEchoServer port action = do
         forever $ do
             msg <- receiveDataMessage conn
             sendDataMessage conn msg
+
+    handleClose :: IORef Bool -> ConnectionException -> IO ()
+    handleClose cRef (CloseRequest i msg) = do
+        i @=? 1000
+        msg @=? expectedClose
+        writeIORef cRef True
+    handleClose _ ConnectionClosed = error "Unexpected connection closed exception"
+
+
+--------------------------------------------------------------------------------
+expectCloseException :: Connection -> BL.ByteString -> IO ()
+expectCloseException conn msg = act `catch` handler
+    where
+        act = receiveDataMessage conn >> error "Expecting CloseRequest exception"
+        handler (CloseRequest i msg') = do
+            i @=? 1000
+            msg' @=? msg
+        handler ConnectionClosed = error "Unexpected connection closed"

--- a/tests/haskell/Network/WebSockets/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Tests.hs
@@ -108,8 +108,9 @@ instance Arbitrary Frame where
 instance Arbitrary Message where
     arbitrary = do
         payload <- BL.pack <$> arbitrary
+        closecode <- arbitrary
         QC.elements
-            [ ControlMessage (Close payload)
+            [ ControlMessage (Close closecode payload)
             , ControlMessage (Ping payload)
             , ControlMessage (Pong payload)
             , DataMessage (Text payload)

--- a/tests/javascript/client.js
+++ b/tests/javascript/client.js
@@ -35,9 +35,14 @@ asyncTest('echo-text', function() {
         if(messages.length > 0) {
             ws.send(messages[0]);
         } else {
-            ws.close();
-            start();
+            ws.close(4002, "Goodbye");
         }
+    };
+
+    ws.onclose = function(event) {
+        equal(event.code, 4002);
+        equal(event.reason, "Goodbye");
+        start();
     };
 });
 
@@ -46,8 +51,9 @@ asyncTest('close me', function() {
     ws.onopen = function() {
         ws.send('Close me!');
     };
-    ws.onclose = function() {
-        ok(true, 'closed');
+    ws.onclose = function(event) {
+        equal(event.code, 1000);
+        equal(event.reason, "Closing");
         start();
     };
 });
@@ -76,5 +82,12 @@ asyncTest('blob', function() {
     ws.onmessage = function(event){
         console.log(event.data)
         console.log(event.data.type)
+        ws.close();
+    };
+
+    ws.onclose = function(event) {
+        equal(event.code, 1000);
+        equal(event.reason, "");
+        start();
     };
 });

--- a/tests/javascript/server.hs
+++ b/tests/javascript/server.hs
@@ -8,8 +8,9 @@ module Main
 
 
 --------------------------------------------------------------------------------
-import           Control.Monad              (forM_, forever)
+import           Control.Monad              (forM_, forever, void)
 import           Control.Monad.Trans        (liftIO)
+import           Control.Exception          (catch)
 import           Data.ByteString            (ByteString)
 import           Data.ByteString.Lazy.Char8 ()
 import           Data.Text                  (Text)
@@ -33,7 +34,10 @@ closeMe :: WS.Connection -> IO ()
 closeMe conn = do
     msg <- WS.receiveData conn
     case (msg :: TL.Text) of
-        "Close me!" -> WS.close conn
+        "Close me!" -> do
+            WS.sendClose conn ("Closing" :: ByteString)
+            void $ WS.receiveDataMessage conn
+            error "Expecting receiveDataMessage to throw CloseRequest exception"
         _           -> error "closeme: unexpected input"
 
 
@@ -80,11 +84,15 @@ application pc = do
     -- liftIO $ putStrLn $ "Selected version: " ++ version''
     let name = WS.requestPath rq
     liftIO $ putStrLn $ "Starting test " ++ show name
-    let Just test = lookup name tests in test conn
+    let Just test = lookup name tests in test conn `catch` handleClose
     liftIO $ putStrLn $ "Test " ++ show name ++ " finished"
   where
     rq       = WS.pendingRequest pc
     version' = lookup "Sec-WebSocket-Version" (WS.requestHeaders rq)
+    handleClose (WS.CloseRequest i msg) =
+        putStrLn $ "Recevied close request " ++ show i ++ " : " ++ show msg
+    handleClose WS.ConnectionClosed =
+        putStrLn "Unexpected connection closed exception"
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is essentially the same as the previous pull request.  Note that the test suite won't compile without the newQCGen change from the subprotocol pull request, and I have only run the javascript tests on the merge of these two pulls.
