### PR TITLE
Add support for Windows

### DIFF
--- a/example/client.hs
+++ b/example/client.hs
@@ -9,6 +9,7 @@ module Main
 import           Control.Concurrent  (forkIO)
 import           Control.Monad       (forever, unless)
 import           Control.Monad.Trans (liftIO)
+import           Network.Socket      (withSocketsDo)
 import           Data.Text           (Text)
 import qualified Data.Text           as T
 import qualified Data.Text.IO        as T
@@ -36,4 +37,4 @@ app conn = do
 
 --------------------------------------------------------------------------------
 main :: IO ()
-main = WS.runClient "echo.websocket.org" 80 "/" app
+main = withSocketsDo $ WS.runClient "echo.websocket.org" 80 "/" app


### PR DESCRIPTION
Add support for Windows with withSocketsDo. Without this running the client on Windows results in **\* Exception: getAddrInfo: does not exist (error 10093)
