### PR TITLE
Change makePendingConnection to accept a Stream instead of a Socket

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -53,6 +53,7 @@ module Network.WebSockets
       -- * Utilities for writing your own server
     , makeListenSocket
     , makePendingConnection
+    , makePendingConnectionFromStream
 
       -- * Running a client
     , ClientApp

--- a/src/Network/WebSockets/Server.hs
+++ b/src/Network/WebSockets/Server.hs
@@ -84,16 +84,16 @@ runApp :: Socket
        -> ServerApp
        -> IO ()
 runApp socket opts app = do
-    pending <- makePendingConnection socket opts
+    stream  <- Stream.makeSocketStream socket
+    pending <- makePendingConnection stream opts
     app pending
 
 
 --------------------------------------------------------------------------------
--- | Turns a socket, connected to some client, into a 'PendingConnection'.
+-- | Turns a stream, connected to some client, into a 'PendingConnection'.
 makePendingConnection
-    :: Socket -> ConnectionOptions -> IO PendingConnection
-makePendingConnection sock opts = do
-    stream   <- Stream.makeSocketStream sock
+    :: Stream.Stream -> ConnectionOptions -> IO PendingConnection
+makePendingConnection stream opts = do
     -- TODO: we probably want to send a 40x if the request is bad?
     mbRequest <- Stream.parse stream (decodeRequestHead False)
     case mbRequest of

--- a/src/Network/WebSockets/Server.hs
+++ b/src/Network/WebSockets/Server.hs
@@ -9,6 +9,7 @@ module Network.WebSockets.Server
     , runServerWith
     , makeListenSocket
     , makePendingConnection
+    , makePendingConnectionFromStream
     ) where
 
 
@@ -84,16 +85,23 @@ runApp :: Socket
        -> ServerApp
        -> IO ()
 runApp socket opts app = do
-    stream  <- Stream.makeSocketStream socket
-    pending <- makePendingConnection stream opts
+    pending <- makePendingConnection socket opts
     app pending
 
 
 --------------------------------------------------------------------------------
--- | Turns a stream, connected to some client, into a 'PendingConnection'.
+-- | Turns a socket, connected to some client, into a 'PendingConnection'.
 makePendingConnection
+    :: Socket -> ConnectionOptions -> IO PendingConnection
+makePendingConnection socket opts = do
+    stream  <- Stream.makeSocketStream socket
+    makePendingConnectionFromStream stream opts
+
+-- | More general version of 'makePendingConnection' for 'Stream.Stream'
+-- instead of a 'Socket'.
+makePendingConnectionFromStream
     :: Stream.Stream -> ConnectionOptions -> IO PendingConnection
-makePendingConnection stream opts = do
+makePendingConnectionFromStream stream opts = do
     -- TODO: we probably want to send a 40x if the request is bad?
     mbRequest <- Stream.parse stream (decodeRequestHead False)
     case mbRequest of


### PR DESCRIPTION
Hi!

I'd like to propose the following change: Use a `Stream` argument for `makePendingConnection` instead of a `Socket`. This allows the use of more general streams, e.g. for a TLS connection. Currently, this is the easiest and cleanest solution since it is not possible to implement something like `makePendingConnection` outside of the websockets library because of the `decodeRequestHead` function, which is a private function from the hidden module `Network.Websockets.HTTP`.

This change does break the current API, but I think it is a reasonable change and easy to fix for any users of this function (see e.g. the change in `runApp`).

– McManiaC