### PR TITLE
Add routing module for pending connections

### DIFF
--- a/src/Network/WebSockets/Routing.hs
+++ b/src/Network/WebSockets/Routing.hs
@@ -179,7 +179,6 @@ noTrailingSlash = do
 path :: (String -> WebSocketsRoute a) -> WebSocketsRoute a
 path r = do
     pending <- askPending
-    liftIO $ print $ pendingRequest pending
     case paths pending of
         (p:ps) | p /= "." -> -- makeRelative turns "/" into ["."]
             withPending (setPath ps) (r $ dropTrailingPathSeparator p)

--- a/src/Network/WebSockets/Routing.hs
+++ b/src/Network/WebSockets/Routing.hs
@@ -3,22 +3,26 @@
 
 -- | WebSockets routing for incoming 'PendingConnection'.
 module Network.WebSockets.Routing
-  ( WebSocketsRoute
-  , routeWebSockets
-  , askPending
+    ( WebSocketsRoute
+    , routeWebSockets
+    , askPending
 
-    -- * Accepting a request
-  , routeAccept
-  , routeAcceptWith
+      -- * Accepting a request
+    , routeAccept
+    , routeAcceptWith
 
-    -- * Route by path info
-  , dir
-  , dirs
-  , nullDir
-  , trailingSlash
-  , noTrailingSlash
-  , path
-  ) where
+       -- * Route by subprotocol
+    , subprotocol
+    , noSubprotocols
+
+      -- * Route by path info
+    , dir
+    , dirs
+    , nullDir
+    , trailingSlash
+    , noTrailingSlash
+    , path
+    ) where
 
 import           Control.Applicative
 import           Control.Monad
@@ -26,54 +30,94 @@ import           Control.Monad.Reader
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
 import           Network.WebSockets
-import           System.FilePath (makeRelative, splitDirectories)
+import           System.FilePath -- (makeRelative, splitDirectories)
 
 -- | The main routing monad.
 newtype WebSocketsRoute a = WebSocketsRoute
-  { unWebSocketsRoute :: ReaderT PendingConnection IO a
-  } deriving (Functor, Applicative, Monad, MonadIO, Alternative, MonadPlus)
+    { unWebSocketsRoute :: ReaderT (PendingConnection, Maybe ByteString) IO a
+    } deriving (Functor, Applicative, Monad, MonadIO, Alternative, MonadPlus)
 
 -- | Route websocket requests. If no route is accepted the connection will be
 -- rejected.
 routeWebSockets :: WebSocketsRoute () -> ServerApp
 routeWebSockets route pending =
-  runReaderT (unWebSocketsRoute (route <|> reject)) pending
- where
-  reject = liftIO $ rejectRequest pending ""
+    runReaderT (unWebSocketsRoute (route <|> reject)) (pending, Nothing)
+  where
+    reject = liftIO $ rejectRequest pending ""
 
--- | Get the current pending connection
+-- | Get the current pending connection. Note that certain functions like e.g.
+-- 'dir' may modify the 'RequestHead' on subroutes.
 askPending :: WebSocketsRoute PendingConnection
-askPending = WebSocketsRoute ask
+askPending = WebSocketsRoute $ asks fst
+
+-- helper
+askSubprotocol :: WebSocketsRoute (Maybe ByteString)
+askSubprotocol = WebSocketsRoute $ asks snd
 
 --------------------------------------------------------------------------------
 -- Helper functions
 
 withPending :: (PendingConnection -> PendingConnection) -> WebSocketsRoute a -> WebSocketsRoute a
-withPending f r = WebSocketsRoute $ withReaderT f (unWebSocketsRoute r)
+withPending f r = WebSocketsRoute $ withReaderT (\(p,s) -> (f p,s)) (unWebSocketsRoute r)
+
+setProto :: Maybe ByteString -> WebSocketsRoute a -> WebSocketsRoute a
+setProto bs r = WebSocketsRoute $ withReaderT (\(p,_) -> (p,bs)) (unWebSocketsRoute r)
 
 setPath :: [String] -> PendingConnection -> PendingConnection
 setPath bs pending =
-  pending { pendingRequest = (pendingRequest pending) { requestPath = unpaths bs } }
+    pending { pendingRequest = (pendingRequest pending) { requestPath = unpaths bs } }
 
 paths :: PendingConnection -> [String]
-paths = splitDirectories . makeRelative "/" . B8.unpack . requestPath . pendingRequest
+paths = splitPath . makeRelative "/" . B8.unpack . requestPath . pendingRequest
 
 unpaths :: [String] -> ByteString
-unpaths = B8.intercalate "/" . map B8.pack
+unpaths = B8.pack . joinPath
 
 --------------------------------------------------------------------------------
 -- Accept requests
 
--- | Accept a request. Every request should only be accepted once.
+-- | Accept a request. If a route has been chosen using 'subprotocol' the
+-- corresponding subprotocol will be selected for the connection.
+--
+-- Every request should only be accepted once.
 routeAccept :: (Connection -> IO a) -> WebSocketsRoute a
 routeAccept go = do
-  pending <- askPending
-  liftIO $ go =<< acceptRequest pending
+    proto <- askSubprotocol
+    routeAcceptWith (AcceptRequest proto) go
 
+-- | Accept a request and overwrite the default sub protocol and using the
+-- given 'AcceptRequest' instead.
 routeAcceptWith :: AcceptRequest -> (Connection -> IO a) -> WebSocketsRoute a
 routeAcceptWith req go = do
-  pending <- askPending
-  liftIO $ go =<< acceptRequestWith pending req
+    pending <- askPending
+    liftIO $ go =<< acceptRequestWith pending req
+
+--------------------------------------------------------------------------------
+-- Route by subprotocol
+
+-- | Route by available subprotocols. If any of the protocols in the header
+-- matches the route will succeed.
+--
+-- > route :: WebSocketsRoute ()
+-- > route = msum [ subprotocol "json" $ jsonRoute
+-- >              , subprotocol "html" $ htmlRoute ]
+--
+-- Calling 'routeAccept' on the inner route will automatically send the
+-- selected subprotocol to the client.
+subprotocol :: ByteString -> WebSocketsRoute a -> WebSocketsRoute a
+subprotocol proto w = do
+    p <- askPending
+    let reqProto = getRequestSubprotocols . pendingRequest $ p
+    if proto `elem` reqProto then
+        setProto (Just proto) w
+      else
+        mzero
+
+-- | Guard which only succeeds if no subprotocols have been requested.
+noSubprotocols :: WebSocketsRoute ()
+noSubprotocols = do
+    p <- askPending
+    guard $ null . getRequestSubprotocols . pendingRequest $ p
 
 --------------------------------------------------------------------------------
 -- Route by path info
@@ -87,10 +131,13 @@ routeAcceptWith req go = do
 -- The path element can not contain \'/\'. See also 'dirs'.
 dir :: String -> WebSocketsRoute a -> WebSocketsRoute a
 dir p r = do
-  pending <- askPending
-  case paths pending of
-    (p':ps) | p == p' -> withPending (setPath ps) r
-    _                 -> mzero
+    pending <- askPending
+    case paths pending of
+        (p':ps) | p == dropTrailingPathSeparator p' -> do
+            let ps' | hasTrailingPathSeparator p' = "/" : ps
+                    | otherwise                   =       ps
+            withPending (setPath ps') r
+        _ -> mzero
 
 -- | Guard against a 'FilePath'. Unlike 'dir' the 'FilePath' may contain \'/\'.
 -- If the guard succeeds, the matched elements will be popped from the directory stack.
@@ -100,34 +147,40 @@ dir p r = do
 -- See also: 'dir'.
 dirs :: FilePath -> WebSocketsRoute a -> WebSocketsRoute a
 dirs fp w = do
-  let parts = splitDirectories $ makeRelative "/" fp
-  foldr dir w parts
+    let parts = splitDirectories $ makeRelative "/" fp
+    foldr dir w parts
 
 -- | Guard which only succeeds if there are no remaining path segments. Often
 -- used if you want to explicitly assign a route for \'/\'.
 nullDir :: WebSocketsRoute ()
 nullDir = do
-  pending <- askPending
-  guard $ null (paths pending)
+    pending <- askPending
+    guard $ null (paths pending)
 
 -- | Guard which checks that the request URI ends in \'/\'. Useful for
 -- distinguishing between @foo@ and @foo/@.
 trailingSlash :: WebSocketsRoute ()
 trailingSlash = do
-  pending <- askPending
-  guard $ ('/' ==) . B8.last . requestPath . pendingRequest $ pending
+    pending <- askPending
+    case B8.unsnoc . requestPath . pendingRequest $ pending of
+        Just (_, '/') -> return ()
+        _             -> mzero
 
 -- | The opposite of 'trailingSlash'
 noTrailingSlash :: WebSocketsRoute ()
 noTrailingSlash = do
-  pending <- askPending
-  guard $ ('/' /=) . B8.last . requestPath . pendingRequest $ pending
+    pending <- askPending
+    case B8.unsnoc . requestPath . pendingRequest $ pending of
+        Just (_, '/') -> mzero
+        _             -> return ()
 
 -- | Pop any path element and run the websocket route. Succeeds if a path
 -- component was popped. Fails if the remaining path was empty.
 path :: (String -> WebSocketsRoute a) -> WebSocketsRoute a
 path r = do
-  pending <- askPending
-  case paths pending of
-    (p:ps) -> withPending (setPath ps) (r p)
-    _      -> mzero
+    pending <- askPending
+    liftIO $ print $ pendingRequest pending
+    case paths pending of
+        (p:ps) | p /= "." -> -- makeRelative turns "/" into ["."]
+            withPending (setPath ps) (r $ dropTrailingPathSeparator p)
+        _ -> mzero

--- a/src/Network/WebSockets/Routing.hs
+++ b/src/Network/WebSockets/Routing.hs
@@ -1,0 +1,133 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | WebSockets routing for incoming 'PendingConnection'.
+module Network.WebSockets.Routing
+  ( WebSocketsRoute
+  , routeWebSockets
+  , askPending
+
+    -- * Accepting a request
+  , routeAccept
+  , routeAcceptWith
+
+    -- * Route by path info
+  , dir
+  , dirs
+  , nullDir
+  , trailingSlash
+  , noTrailingSlash
+  , path
+  ) where
+
+import           Control.Applicative
+import           Control.Monad
+import           Control.Monad.Reader
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as B8
+import           Network.WebSockets
+import           System.FilePath (makeRelative, splitDirectories)
+
+-- | The main routing monad.
+newtype WebSocketsRoute a = WebSocketsRoute
+  { unWebSocketsRoute :: ReaderT PendingConnection IO a
+  } deriving (Functor, Applicative, Monad, MonadIO, Alternative, MonadPlus)
+
+-- | Route websocket requests. If no route is accepted the connection will be
+-- rejected.
+routeWebSockets :: WebSocketsRoute () -> ServerApp
+routeWebSockets route pending =
+  runReaderT (unWebSocketsRoute (route <|> reject)) pending
+ where
+  reject = liftIO $ rejectRequest pending ""
+
+-- | Get the current pending connection
+askPending :: WebSocketsRoute PendingConnection
+askPending = WebSocketsRoute ask
+
+--------------------------------------------------------------------------------
+-- Helper functions
+
+withPending :: (PendingConnection -> PendingConnection) -> WebSocketsRoute a -> WebSocketsRoute a
+withPending f r = WebSocketsRoute $ withReaderT f (unWebSocketsRoute r)
+
+setPath :: [String] -> PendingConnection -> PendingConnection
+setPath bs pending =
+  pending { pendingRequest = (pendingRequest pending) { requestPath = unpaths bs } }
+
+paths :: PendingConnection -> [String]
+paths = splitDirectories . makeRelative "/" . B8.unpack . requestPath . pendingRequest
+
+unpaths :: [String] -> ByteString
+unpaths = B8.intercalate "/" . map B8.pack
+
+--------------------------------------------------------------------------------
+-- Accept requests
+
+-- | Accept a request. Every request should only be accepted once.
+routeAccept :: (Connection -> IO a) -> WebSocketsRoute a
+routeAccept go = do
+  pending <- askPending
+  liftIO $ go =<< acceptRequest pending
+
+routeAcceptWith :: AcceptRequest -> (Connection -> IO a) -> WebSocketsRoute a
+routeAcceptWith req go = do
+  pending <- askPending
+  liftIO $ go =<< acceptRequestWith pending req
+
+--------------------------------------------------------------------------------
+-- Route by path info
+
+-- | Pop a path element and run the supplied handler if it matches the given
+-- string.
+--
+-- > route :: WebSocketsRoute ()
+-- > route = dir "foo" $ dir "bar" $ subRoute
+--
+-- The path element can not contain \'/\'. See also 'dirs'.
+dir :: String -> WebSocketsRoute a -> WebSocketsRoute a
+dir p r = do
+  pending <- askPending
+  case paths pending of
+    (p':ps) | p == p' -> withPending (setPath ps) r
+    _                 -> mzero
+
+-- | Guard against a 'FilePath'. Unlike 'dir' the 'FilePath' may contain \'/\'.
+-- If the guard succeeds, the matched elements will be popped from the directory stack.
+--
+-- > dirs "foo/bar" $ ...
+--
+-- See also: 'dir'.
+dirs :: FilePath -> WebSocketsRoute a -> WebSocketsRoute a
+dirs fp w = do
+  let parts = splitDirectories $ makeRelative "/" fp
+  foldr dir w parts
+
+-- | Guard which only succeeds if there are no remaining path segments. Often
+-- used if you want to explicitly assign a route for \'/\'.
+nullDir :: WebSocketsRoute ()
+nullDir = do
+  pending <- askPending
+  guard $ null (paths pending)
+
+-- | Guard which checks that the request URI ends in \'/\'. Useful for
+-- distinguishing between @foo@ and @foo/@.
+trailingSlash :: WebSocketsRoute ()
+trailingSlash = do
+  pending <- askPending
+  guard $ ('/' ==) . B8.last . requestPath . pendingRequest $ pending
+
+-- | The opposite of 'trailingSlash'
+noTrailingSlash :: WebSocketsRoute ()
+noTrailingSlash = do
+  pending <- askPending
+  guard $ ('/' /=) . B8.last . requestPath . pendingRequest $ pending
+
+-- | Pop any path element and run the websocket route. Succeeds if a path
+-- component was popped. Fails if the remaining path was empty.
+path :: (String -> WebSocketsRoute a) -> WebSocketsRoute a
+path r = do
+  pending <- askPending
+  case paths pending of
+    (p:ps) -> withPending (setPath ps) (r p)
+    _      -> mzero

--- a/tests/haskell/Network/WebSockets/Handshake/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Handshake/Tests.hs
@@ -22,7 +22,6 @@ import           Network.WebSockets
 import           Network.WebSockets.Connection
 import           Network.WebSockets.Http
 import qualified Network.WebSockets.Stream      as Stream
-import           Network.WebSockets.Tests.Util
 
 
 --------------------------------------------------------------------------------

--- a/tests/haskell/Network/WebSockets/Routing/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Routing/Tests.hs
@@ -24,15 +24,15 @@ import           Network.WebSockets.Routing
 --------------------------------------------------------------------------------
 tests :: Test
 tests = testGroup "Network.WebSockets.Routing.Tests"
-    [ testCase "echo routes"     testEchoRoutes
+    [ testCase "dir/dirs routes" testDirRoutes
     , testCase "trailing routes" testTrailingRoutes
     , testCase "path routes"     testPathRoutes
     ]
 
 
 --------------------------------------------------------------------------------
-testEchoRoutes :: Assertion
-testEchoRoutes = withServer port server $ do
+testDirRoutes :: Assertion
+testDirRoutes = withServer port server $ do
 
     assert =<< runClient "127.0.0.1" port "/echo"        echoOnce
     assert =<< runClient "127.0.0.1" port "/echo/twice"  echoTwice
@@ -50,7 +50,7 @@ testEchoRoutes = withServer port server $ do
             send con msg
             send con msg
 
-        -- test 'dir' and 'nullDir'
+        -- test (nested) 'dir' and 'nullDir'
         , dir "echo" $ msum
             [ do
                 nullDir
@@ -122,7 +122,9 @@ testPathRoutes = withServer port server $ do
         msg <- receiveData con
         return $ (msg :: Text) == expected
 
+
 --------------------------------------------------------------------------------
+-- | Helper function to run simple server-client interactions
 withServer :: Int -> ServerApp -> IO a -> IO a
 withServer port server action = do
     serverThread <- forkIO $ retry $ runServer "0.0.0.0" port (\c -> server c)

--- a/tests/haskell/TestSuite.hs
+++ b/tests/haskell/TestSuite.hs
@@ -6,6 +6,7 @@ import           Test.Framework                     (defaultMain)
 import qualified Network.WebSockets.Handshake.Tests
 import qualified Network.WebSockets.Http.Tests
 import qualified Network.WebSockets.Server.Tests
+import qualified Network.WebSockets.Routing.Tests
 import qualified Network.WebSockets.Tests
 
 
@@ -15,5 +16,6 @@ main = defaultMain
     [ Network.WebSockets.Handshake.Tests.tests
     , Network.WebSockets.Http.Tests.tests
     , Network.WebSockets.Server.Tests.tests
+    , Network.WebSockets.Routing.Tests.tests
     , Network.WebSockets.Tests.tests
     ]

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -91,6 +91,7 @@ Test-suite websockets-tests
     Network.WebSockets.Handshake.Tests
     Network.WebSockets.Http.Tests
     Network.WebSockets.Server.Tests
+    Network.WebSockets.Routing.Tests
     Network.WebSockets.Tests
     Network.WebSockets.Tests.Util
 

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -51,6 +51,7 @@ Library
     Network.WebSockets
     Network.WebSockets.Connection
     Network.WebSockets.Stream
+    Network.WebSockets.Routing
     -- Network.WebSockets.Util.PubSub TODO
 
   Other-modules:

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -72,12 +72,13 @@ Library
     bytestring        >= 0.9    && < 0.11,
     case-insensitive  >= 0.3    && < 1.3,
     containers        >= 0.3    && < 0.6,
-    mtl               >= 2.0    && < 2.3,
+    mtl               >= 2.2    && < 2.3,
     network           >= 2.3    && < 2.7,
     random            >= 1.0    && < 1.2,
     SHA               >= 1.5    && < 1.7,
     text              >= 0.10   && < 1.3,
-    entropy           >= 0.2.1  && < 0.4
+    entropy           >= 0.2.1  && < 0.4,
+    filepath          >= 1.3    && < 1.5
 
 Test-suite websockets-tests
   Type:           exitcode-stdio-1.0
@@ -107,12 +108,13 @@ Test-suite websockets-tests
     bytestring        >= 0.9    && < 0.11,
     case-insensitive  >= 0.3    && < 1.3,
     containers        >= 0.3    && < 0.6,
-    mtl               >= 2.0    && < 2.3,
+    mtl               >= 2.2    && < 2.3,
     network           >= 2.3    && < 2.7,
     random            >= 1.0    && < 1.2,
     SHA               >= 1.5    && < 1.7,
     text              >= 0.10   && < 1.3,
-    entropy           >= 0.2.1  && < 0.4
+    entropy           >= 0.2.1  && < 0.4,
+    filepath          >= 1.3    && < 1.5
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
As discussed in our mails, here is my routing module proposal. The idea is based on [happstacks routing module](http://hackage.haskell.org/package/happstack-server-7.4.3/docs/Happstack-Server-Routing.html). It is "non intrusive" in that it does not require changes to any of the underlying types (`PendingConnection` or `Connection`). I also added a couple of test cases for it. I had to however raise the dependency on `mtl` from version `>= 2.0` to `>= 2.2` to be able to use `Alternative` and `MonadPlus` instances for the `WebSocketsRoute` monad.

Please take a look and let me know what you think.