### PR TITLE
Needs GHC >= 7.2 due to usage of forkIOWithUnmask

### DIFF
--- a/websockets.cabal
+++ b/websockets.cabal
@@ -70,7 +70,7 @@ Library
 
   Build-depends:
     attoparsec        >= 0.10   && < 0.14,
-    base              >= 4      && < 5,
+    base              >= 4.4    && < 5,
     base64-bytestring >= 0.1    && < 1.1,
     binary            >= 0.5    && < 0.9,
     blaze-builder     >= 0.3    && < 0.5,


### PR DESCRIPTION
```
src/Network/WebSockets/Server.hs:17:49:
    Module `Control.Concurrent' does not export `forkIOWithUnmask'
```

I added revisions for this: https://hackage.haskell.org/package/websockets-0.9.6.2/revisions/