### PR TITLE
Allow sending of collections of messages all at once

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -23,6 +23,7 @@ module Network.WebSockets
     , send
     , sendDataMessage
     , sendTextData
+    , sendTextDatas
     , sendBinaryData
     , sendClose
     , sendPing

--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -19,9 +19,11 @@ module Network.WebSockets.Connection
     , receiveData
     , send
     , sendDataMessage
+    , sendDataMessages
     , sendTextData
     , sendTextDatas
     , sendBinaryData
+    , sendBinaryDatas
     , sendClose
     , sendCloseCode
     , sendPing
@@ -210,7 +212,7 @@ receiveData conn = do
 
 --------------------------------------------------------------------------------
 send :: Connection -> Message -> IO ()
-send conn msg = sendAll conn [msg]
+send conn = sendAll conn . return
 
 --------------------------------------------------------------------------------
 sendAll :: Connection -> [Message] -> IO ()
@@ -225,7 +227,7 @@ sendAll conn msgs = do
 --------------------------------------------------------------------------------
 -- | Send a 'DataMessage'
 sendDataMessage :: Connection -> DataMessage -> IO ()
-sendDataMessage conn = send conn . DataMessage
+sendDataMessage conn = sendDataMessages conn . return
 
 --------------------------------------------------------------------------------
 -- | Send a collection of 'DataMessage's
@@ -235,19 +237,22 @@ sendDataMessages conn = sendAll conn . map DataMessage
 --------------------------------------------------------------------------------
 -- | Send a message as text
 sendTextData :: WebSocketsData a => Connection -> a -> IO ()
-sendTextData conn = sendDataMessage conn . Text . toLazyByteString
+sendTextData conn = sendTextDatas conn . return
 
 --------------------------------------------------------------------------------
 -- | Send a collection of messages as text
 sendTextDatas :: WebSocketsData a => Connection -> [a] -> IO ()
 sendTextDatas conn = sendDataMessages conn . map (Text . toLazyByteString)
 
-
 --------------------------------------------------------------------------------
 -- | Send a message as binary data
 sendBinaryData :: WebSocketsData a => Connection -> a -> IO ()
-sendBinaryData conn = sendDataMessage conn . Binary . toLazyByteString
+sendBinaryData conn = sendBinaryDatas conn . return
 
+--------------------------------------------------------------------------------
+-- | Send a collection of messages as binary data
+sendBinaryDatas :: WebSocketsData a => Connection -> [a] -> IO ()
+sendBinaryDatas conn = sendDataMessages conn . map (Binary . toLazyByteString)
 
 --------------------------------------------------------------------------------
 -- | Send a friendly close message.  Note that after sending this message,

--- a/src/Network/WebSockets/Protocol.hs
+++ b/src/Network/WebSockets/Protocol.hs
@@ -68,7 +68,7 @@ finishResponse Hybi13 = Hybi13.finishResponse
 --------------------------------------------------------------------------------
 encodeMessages
     :: Protocol -> ConnectionType -> Stream
-    -> IO (Message -> IO ())
+    -> IO ([Message] -> IO ())
 encodeMessages Hybi13 = Hybi13.encodeMessages
 
 

--- a/tests/haskell/Network/WebSockets/Server/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Server/Tests.hs
@@ -11,7 +11,7 @@ import           Control.Applicative            ((<$>))
 import           Control.Concurrent             (forkIO, killThread,
                                                  threadDelay)
 import           Control.Exception              (SomeException, handle, catch)
-import           Control.Monad                  (forM_, forever, replicateM, unless)
+import           Control.Monad                  (forever, replicateM, unless)
 import           Data.IORef                     (newIORef, readIORef, IORef,
                                                  writeIORef)
 
@@ -42,14 +42,18 @@ tests = testGroup "Network.WebSockets.Server.Tests"
 
 --------------------------------------------------------------------------------
 testSimpleServerClient :: Assertion
-testSimpleServerClient = withEchoServer 42940 "Bye" $ do
+testSimpleServerClient = testServerClient $ \conn -> mapM_ (sendTextData conn)
+
+--------------------------------------------------------------------------------
+testServerClient :: (Connection -> [BL.ByteString] -> IO ()) -> Assertion
+testServerClient sendMessages = withEchoServer 42940 "Bye" $ do
     texts  <- map unArbitraryUtf8 <$> sample
     texts' <- retry $ runClient "127.0.0.1" 42940 "/chat" $ client texts
     texts @=? texts'
   where
     client :: [BL.ByteString] -> ClientApp [BL.ByteString]
     client texts conn = do
-        forM_ texts (sendTextData conn)
+        sendMessages conn texts
         texts' <- replicateM (length texts) (receiveData conn)
         sendClose conn ("Bye" :: BL.ByteString)
         expectCloseException conn "Bye"

--- a/tests/haskell/Network/WebSockets/Server/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Server/Tests.hs
@@ -36,6 +36,7 @@ import           Network.WebSockets.Tests.Util
 tests :: Test
 tests = testGroup "Network.WebSockets.Server.Tests"
     [ testCase "simple server/client" testSimpleServerClient
+    , testCase "bulk server/client"   testBulkServerClient
     , testCase "onPong"               testOnPong
     ]
 
@@ -43,6 +44,10 @@ tests = testGroup "Network.WebSockets.Server.Tests"
 --------------------------------------------------------------------------------
 testSimpleServerClient :: Assertion
 testSimpleServerClient = testServerClient $ \conn -> mapM_ (sendTextData conn)
+
+--------------------------------------------------------------------------------
+testBulkServerClient :: Assertion
+testBulkServerClient = testServerClient sendTextDatas
 
 --------------------------------------------------------------------------------
 testServerClient :: (Connection -> [BL.ByteString] -> IO ()) -> Assertion

--- a/tests/haskell/Network/WebSockets/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Tests.hs
@@ -49,7 +49,7 @@ testSimpleEncodeDecode protocol = QC.monadicIO $
         echo  <- Stream.makeEchoStream
         parse <- decodeMessages protocol echo
         write <- encodeMessages protocol ClientConnection echo
-        _     <- forkIO $ forM_ msgs write
+        _     <- forkIO $ write msgs
         msgs' <- catMaybes <$> replicateM (length msgs) parse
         Stream.close echo
         msgs @=? msgs'


### PR DESCRIPTION
For discussion, for now.

Looking into the performance issues as discussed in https://github.com/bitemyapp/websocket-shootout/pull/3 I believe it would be useful to be able to send a list of messages all at once, rather than sending them one-at-a-time.

This PR, as it currently stands, extends the `websockets` API just enough to support this, and it does seem to help performance-wise.

If encouraged, I'll put some effort into finishing it off and making it mergeworthy. I'm a little unhappy with how things are named, so advice on better names is most welcome.