### PR TITLE
add IPv6 support

### DIFF
--- a/src/Network/WebSockets/Client.hs
+++ b/src/Network/WebSockets/Client.hs
@@ -56,18 +56,18 @@ runClientWith :: String             -- ^ Host
 runClientWith host port path0 opts customHeaders app = do
     -- Create and connect socket
     let hints = S.defaultHints
-                    {S.addrFamily = S.AF_INET, S.addrSocketType = S.Stream}
+                    {S.addrSocketType = S.Stream}
 
         -- Correct host and path.
         fullHost = if port == 80 then host else (host ++ ":" ++ show port)
         path     = if null path0 then "/" else path0
-    addrInfos <- S.getAddrInfo (Just hints) (Just host) (Just $ show port)
-    sock      <- S.socket S.AF_INET S.Stream S.defaultProtocol
+    addr:_ <- S.getAddrInfo (Just hints) (Just host) (Just $ show port)
+    sock      <- S.socket (S.addrFamily addr) S.Stream S.defaultProtocol
     S.setSocketOption sock S.NoDelay 1
 
     -- Connect WebSocket and run client
     res <- finally
-        (S.connect sock (S.addrAddress $ head addrInfos) >>
+        (S.connect sock (S.addrAddress addr) >>
          runClientWithSocket sock fullHost path opts customHeaders app)
         (S.sClose sock)
 


### PR DESCRIPTION
This patch adds support for IPv6 addressing in the client, the server, and tests. All tests pass under Ubuntu 12.04.