### PR TITLE
Performance tweaks

### DIFF
--- a/benchmarks/mask.hs
+++ b/benchmarks/mask.hs
@@ -13,9 +13,11 @@ import qualified Data.ByteString.Lazy as BL
 setupEnv = do
     let kilo = BL.replicate 1024 37
         mega = BL.replicate (1024 * 1024) 37
-    return (kilo, mega)
+        megaU = BL.fromChunks [B.drop 1 (B.replicate (1024 * 1024) 37)]
+        megaS = BL.fromChunks [B.replicate (1024 * 1024) 37]
+    return (kilo, mega, megaU, megaS)
 
-maskPayload' :: Mask -> BL.ByteString -> BL.ByteString
+maskPayload' :: Maybe B.ByteString -> BL.ByteString -> BL.ByteString
 maskPayload' Nothing     = id
 maskPayload' (Just mask) = snd . BL.mapAccumL f (cycle $ B.unpack mask)
   where
@@ -23,40 +25,43 @@ maskPayload' (Just mask) = snd . BL.mapAccumL f (cycle $ B.unpack mask)
     f (m:ms) !c = (ms, m `xor` c)
 
 main = defaultMain [
-    env setupEnv $ \ ~(kilo, mega) -> bgroup "main"
+    env setupEnv $ \ ~(kilo, mega, megaU, megaS) -> bgroup "main"
         [ bgroup "kilobyte payload"
             [ bgroup "zero_mask"
-                [ bench "current" $ nf (maskPayload (Just "\x00\x00\x00\x00")) kilo
+                [ bench "current" $ nf (maskPayload (Just 0)) kilo
                 , bench "old" $ nf (maskPayload' (Just "\x00\x00\x00\x00")) kilo
                 ]
             ,  bgroup "full_mask"
-                [ bench "current" $ nf (maskPayload (Just "\xFF\xFF\xFF\xFF")) kilo
+                [ bench "current" $ nf (maskPayload (Just 0xffffffff)) kilo
+                , bench "current-unaligned" $ nf (maskPayload (Just 0xffffffff)) (BL.drop 1 kilo)
                 , bench "old" $ nf (maskPayload' (Just "\xFF\xFF\xFF\xFF")) kilo
                 ]
             ,  bgroup "one_byte_mask"
-                [ bench "current" $ nf (maskPayload (Just "\xCC\xCC\xCC\xCC")) kilo
+                [ bench "current" $ nf (maskPayload (Just 0xcccccccc)) kilo
                 , bench "old" $ nf (maskPayload' (Just "\xCC\xCC\xCC\xCC")) kilo
                 ]
             ,  bgroup "other_mask"
-                [ bench "current" $ nf (maskPayload (Just "\xB0\xA2\xB0\xA2")) kilo
+                [ bench "current" $ nf (maskPayload (Just 0xa2b0a2b0)) kilo
                 , bench "old" $ nf (maskPayload' (Just "\xB0\xA2\xB0\xA2")) kilo
                 ]
             ]
         , bgroup "megabyte payload"
             [ bgroup "zero_mask"
-                [ bench "current" $ nf (maskPayload (Just "\x00\x00\x00\x00")) mega
+                [ bench "current" $ nf (maskPayload (Just 0)) mega
                 , bench "old" $ nf (maskPayload' (Just "\x00\x00\x00\x00")) mega
                 ]
             ,  bgroup "full_mask"
-                [ bench "current" $ nf (maskPayload (Just "\xFF\xFF\xFF\xFF")) mega
+                [ bench "current" $ nf (maskPayload (Just 0xffffffff)) mega
+                , bench "current-unaligned" $ nf (maskPayload (Just 0xffffffff)) megaU
+                , bench "current-aligned" $ nf (maskPayload (Just 0xffffffff)) megaS
                 , bench "old" $ nf (maskPayload' (Just "\xFF\xFF\xFF\xFF")) mega
                 ]
             ,  bgroup "one_byte_mask"
-                [ bench "current" $ nf (maskPayload (Just "\xCC\xCC\xCC\xCC")) mega
+                [ bench "current" $ nf (maskPayload (Just 0xcccccccc)) mega
                 , bench "old" $ nf (maskPayload' (Just "\xCC\xCC\xCC\xCC")) mega
                 ]
             ,  bgroup "other_mask"
-                [ bench "current" $ nf (maskPayload (Just "\xB0\xA2\xB0\xA2")) mega
+                [ bench "current" $ nf (maskPayload (Just 0xa2b0a2b0)) mega
                 , bench "old" $ nf (maskPayload' (Just "\xB0\xA2\xB0\xA2")) mega
                 ]
             ]

--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -6,76 +6,51 @@
 /* Taken from:
  *
  * <http://stackoverflow.com/questions/776508/best-practices-for-circular-shift-rotate-operations-in-c>
+ *
+ * Intel is little-endian, we have to rotate right
  */
-static inline uint32_t rotl32(uint32_t n, unsigned int c) {
-    const unsigned int mask = (CHAR_BIT*sizeof(n)-1);
-    /* avoid undef behaviour with NDEBUG.  0 overhead for most types and
-     * compilers */
-    c &= mask;
-    return (n<<c) | (n>>( (-c)&mask ));
+static inline uint32_t rotr32(uint32_t n, unsigned int c) {
+  const unsigned int mask = (CHAR_BIT*sizeof(n)-1);
+  c &= mask;  // avoid undef behaviour with NDEBUG.  0 overhead for most types / compilers
+  return (n>>c) | (n<<( (-c)&mask ));
 }
 
-/* - mask_shift is the initial shift of the mask.  This value must be 0, 8, 16
- *   or 24.
- *
- * The new mask_shift is returned from this function.
+/* - mask_shift is the initial shift of the mask.  It is specified in bytes.
  */
-int _hs_mask_chunk(
+void _hs_mask_chunk(
         uint32_t mask, int mask_shift,
-        uint8_t *payload_start, size_t payload_len) {
+        uint8_t *payload_start, size_t payload_len,
+        uint8_t *target) {
     const uint8_t *payload_end = payload_start + payload_len;
-
-    uint32_t mask32;
-    uint64_t mask64;
 
     uint8_t *p = payload_start;
 
 #if defined(__x86_64__)
-    /* Un-aligned prefix. */
-    while (p != payload_end && ((uintptr_t)p & 0x7)) {
-        *p ^= (uint8_t)(mask >> mask_shift);
-        p++;
-        mask_shift = mask_shift == 24 ? 0 : (mask_shift + 8);
-    }
-
+    uint64_t mask64;
     /* Set up 64 byte mask. */
-    mask64 = (uint64_t)(rotl32(mask, mask_shift));
+    mask64 = (uint64_t)(rotr32(mask, 8 * (mask_shift % 4)));
     mask64 |= (mask64 << 32);
-
     /* Take the fast road. */
     while (p < payload_end - 7) {
-        uint64_t *p64 = (uint64_t*)p;
-        *p64 ^= mask64;
-        p += 8;
+        *(uint64_t *)target = *(uint64_t*)p ^ mask64;
+        p += 8;target += 8;
     }
-
 #elif defined(__i386__)
-    /* Un-aligned prefix. */
-    while (p != payload_end && ((uintptr_t)p & 0x3)) {
-        *p ^= (uint8_t)(mask >> mask_shift);
-        p++;
-        mask_shift = mask_shift == 24 ? 0 : (mask_shift + 8);
-    }
-
     /* Set up 32 byte mask. */
-    mask32 = (uint64_t)(rotl32(mask, mask_shift));
-    mask32 |= (mask32 << 32);
+    uint32_t mask32;
+    mask32 = (uint32_t)(rotr32(mask, 8 * (mask_shift % 4)));
 
     /* Take the fast road. */
     while (p < payload_end - 3) {
-        uint64_t *p32 = (uint64_t*)p;
-        *p32 ^= mask32;
-        p += 4;
+        *(uint32_t *)target = *(uint32_t*)p ^ mask32;
+        p += 4;target += 4;
     }
-
 #endif
 
     /* This is the slow path which also handles the un-aligned suffix. */
     while (p != payload_end) {
-        *p ^= (uint8_t)(mask >> mask_shift);
-        p++;
-        mask_shift = mask_shift == 24 ? 0 : (mask_shift + 8);
+        *target = *p ^ (uint8_t)(((uint8_t *)&mask)[mask_shift % 4]);
+        p++;target++;
+        mask_shift++;
     }
-
-    return mask_shift;
 }

--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -1,0 +1,81 @@
+#include <stdint.h>
+#include <string.h>
+#include <limits.h>
+#include <assert.h>
+
+/* Taken from:
+ *
+ * <http://stackoverflow.com/questions/776508/best-practices-for-circular-shift-rotate-operations-in-c>
+ */
+static inline uint32_t rotl32(uint32_t n, unsigned int c) {
+    const unsigned int mask = (CHAR_BIT*sizeof(n)-1);
+    /* avoid undef behaviour with NDEBUG.  0 overhead for most types and
+     * compilers */
+    c &= mask;
+    return (n<<c) | (n>>( (-c)&mask ));
+}
+
+/* - mask_shift is the initial shift of the mask.  This value must be 0, 8, 16
+ *   or 24.
+ *
+ * The new mask_shift is returned from this function.
+ */
+int _hs_mask_chunk(
+        uint32_t mask, int mask_shift,
+        uint8_t *payload_start, size_t payload_len) {
+    const uint8_t *payload_end = payload_start + payload_len;
+
+    uint32_t mask32;
+    uint64_t mask64;
+
+    uint8_t *p = payload_start;
+
+#if defined(__x86_64__)
+    /* Un-aligned prefix. */
+    while (p != payload_end && ((uintptr_t)p & 0x7)) {
+        *p ^= (uint8_t)(mask >> mask_shift);
+        p++;
+        mask_shift = mask_shift == 24 ? 0 : (mask_shift + 8);
+    }
+
+    /* Set up 64 byte mask. */
+    mask64 = (uint64_t)(rotl32(mask, mask_shift));
+    mask64 |= (mask64 << 32);
+
+    /* Take the fast road. */
+    while (p < payload_end - 7) {
+        uint64_t *p64 = (uint64_t*)p;
+        *p64 ^= mask64;
+        p += 8;
+    }
+
+#elif defined(__i386__)
+    /* Un-aligned prefix. */
+    while (p != payload_end && ((uintptr_t)p & 0x3)) {
+        *p ^= (uint8_t)(mask >> mask_shift);
+        p++;
+        mask_shift = mask_shift == 24 ? 0 : (mask_shift + 8);
+    }
+
+    /* Set up 32 byte mask. */
+    mask32 = (uint64_t)(rotl32(mask, mask_shift));
+    mask32 |= (mask32 << 32);
+
+    /* Take the fast road. */
+    while (p < payload_end - 3) {
+        uint64_t *p32 = (uint64_t*)p;
+        *p32 ^= mask32;
+        p += 4;
+    }
+
+#endif
+
+    /* This is the slow path which also handles the un-aligned suffix. */
+    while (p != payload_end) {
+        *p ^= (uint8_t)(mask >> mask_shift);
+        p++;
+        mask_shift = mask_shift == 24 ? 0 : (mask_shift + 8);
+    }
+
+    return mask_shift;
+}

--- a/cbits/cbits.c
+++ b/cbits/cbits.c
@@ -49,7 +49,7 @@ void _hs_mask_chunk(
 
     /* This is the slow path which also handles the un-aligned suffix. */
     while (p != payload_end) {
-        *target = *p ^ (uint8_t)(((uint8_t *)&mask)[mask_shift % 4]);
+        *target = *p ^ (((uint8_t *)&mask)[mask_shift % 4]);
         p++;target++;
         mask_shift++;
     }

--- a/src/Network/WebSockets/Hybi13.hs
+++ b/src/Network/WebSockets/Hybi13.hs
@@ -22,7 +22,7 @@ import           Control.Monad                         (forM, liftM, when)
 import           Data.Binary.Get                       (getWord16be,
                                                         getInt64be,
                                                         Get, getLazyByteString,
-                                                        getWord8, getByteString)
+                                                        getWord8, getWord32host)
 import           Data.Binary.Put                       (putWord16be, runPut)
 import           Data.Bits                             ((.&.), (.|.))
 import           Data.ByteString                       (ByteString)
@@ -136,7 +136,7 @@ encodeFrame mask f = B.fromWord8 byte0 `mappend`
 
     (maskflag, maskbytes) = case mask of
         Nothing -> (0x00, mempty)
-        Just m  -> (0x80, B.fromByteString m)
+        Just m  -> (0x80, B.fromStorable m)
 
     byte1 = maskflag .|. lenflag
     len'  = BL.length (framePayload f)
@@ -196,7 +196,7 @@ parseFrame = do
         127 -> getInt64be
         _   -> return (fromIntegral lenflag)
 
-    masker <- maskPayload <$> if mask then Just <$> getByteString 4 else pure Nothing
+    masker <- maskPayload <$> if mask then Just <$> getWord32host else pure Nothing
 
     chunks <- getLazyByteString len
 

--- a/src/Network/WebSockets/Hybi13/Mask.hs
+++ b/src/Network/WebSockets/Hybi13/Mask.hs
@@ -12,37 +12,31 @@ module Network.WebSockets.Hybi13.Mask
 
 
 --------------------------------------------------------------------------------
-import           Data.Bits            (shiftR)
-import           Data.Bits            (shiftL, (.|.))
-import qualified Data.ByteString      as B
 import qualified Data.ByteString.Lazy as BL
-import           Data.Word            (Word32)
+import           Data.Word            (Word32, Word8)
 import           Foreign.C.Types      (CChar (..), CInt (..), CSize (..))
-import           Foreign.Ptr          (Ptr)
-import           System.IO.Unsafe     (unsafePerformIO)
+import           Foreign.Ptr          (Ptr, plusPtr)
 import           System.Random        (RandomGen, random)
+import           Data.ByteString.Lazy.Internal as BL
+import           Data.ByteString.Internal as BS
+import           Foreign.ForeignPtr (withForeignPtr)
 
 
 --------------------------------------------------------------------------------
 foreign import ccall unsafe "_hs_mask_chunk" c_mask_chunk
-    :: Word32 -> CInt -> Ptr CChar -> CSize -> IO CInt
-
+    :: Word32 -> CInt -> Ptr CChar -> CSize -> Ptr Word8 -> IO ()
 
 --------------------------------------------------------------------------------
 -- | ByteString should be exactly 4 bytes long
-type Mask = Maybe B.ByteString
+type Mask = Maybe Word32
 
 
 --------------------------------------------------------------------------------
 -- | Create a random mask
 randomMask :: forall g. RandomGen g => g -> (Mask, g)
-randomMask gen = (Just (B.pack [b1, b2, b3, b4]), gen')
+randomMask gen = (Just int, gen')
   where
-    (!int, !gen') = random gen :: (Int, g)
-    !b1           = fromIntegral $ int `mod` 0x100
-    !b2           = fromIntegral $ int `shiftR` 8  `mod` 0x100
-    !b3           = fromIntegral $ int `shiftR` 16 `mod` 0x100
-    !b4           = fromIntegral $ int `shiftR` 24 `mod` 0x100
+    (!int, !gen') = random gen :: (Word32, g)
 
 
 --------------------------------------------------------------------------------
@@ -50,34 +44,13 @@ randomMask gen = (Just (B.pack [b1, b2, b3, b4]), gen')
 -- bytestring rather than returning a new one.  Use at your own risk.
 maskPayload :: Mask -> BL.ByteString -> BL.ByteString
 maskPayload Nothing                   = id
-maskPayload (Just "\x00\x00\x00\x00") = id
-maskPayload (Just mask)
-    | B.length mask == 4 =
-        BL.fromChunks . unsafePerformIO . go 0 . BL.toChunks
-    | otherwise          =
-        error "Network.WebSockets.Hybi13.Mask: mask length must be 4"
+maskPayload (Just 0) = id
+maskPayload (Just mask) = go 0
   where
-    go :: CInt -> [B.ByteString] -> IO [B.ByteString]
-    go _ [] = return []
-    go shift0 (c0 : chunks) = do
-        -- TODO (jaspervdj): this code copies the string twice:
-        --
-        -- - Once in 'B.useAsCStringLen'
-        -- - Once in 'B.packCStringLen'
-        --
-        -- We should be able to get away with one copy and in some cases zero
-        -- copies.
-        (c1, shift1) <- B.useAsCStringLen c0 $ \(ptr, len) -> do
-            shift1 <- c_mask_chunk mask32 shift0 ptr (fromIntegral len)
-            c1     <- B.packCStringLen (ptr, len)
-            return (c1, shift1)
-        (c1 :) <$> go shift1 chunks
-
-    -- | Puts the mask into a 'Word32' in a way that will allow fast masking on
-    -- little-endian platforms.
-    mask32 :: Word32
-    mask32 =
-        (fromIntegral (B.index mask 0) `shiftL`  0) .|.
-        (fromIntegral (B.index mask 1) `shiftL`  8) .|.
-        (fromIntegral (B.index mask 2) `shiftL` 16) .|.
-        (fromIntegral (B.index mask 3) `shiftL` 24)
+    go _ Empty = Empty
+    go n (Chunk (BS.PS payload off len) rest) =
+        Chunk c1 (go (n + len) rest)
+      where
+        c1 = unsafeCreate len $ \tgt ->
+              withForeignPtr payload $ \ptr ->
+                  c_mask_chunk mask (fromIntegral $ n `rem` 4) (ptr `plusPtr` off) (fromIntegral len) tgt

--- a/src/Network/WebSockets/Hybi13/Mask.hs
+++ b/src/Network/WebSockets/Hybi13/Mask.hs
@@ -1,8 +1,9 @@
 --------------------------------------------------------------------------------
 -- | Masking of fragmes using a simple XOR algorithm
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# language OverloadedStrings   #-}
+{-# LANGUAGE BangPatterns             #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings        #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
 module Network.WebSockets.Hybi13.Mask
     ( Mask
     , maskPayload
@@ -11,31 +12,25 @@ module Network.WebSockets.Hybi13.Mask
 
 
 --------------------------------------------------------------------------------
-import           Data.Bits            (shiftR, xor)
+import           Data.Bits            (shiftR)
+import           Data.Bits            (shiftL, (.|.))
 import qualified Data.ByteString      as B
 import qualified Data.ByteString.Lazy as BL
+import           Data.Word            (Word32)
+import           Foreign.C.Types      (CChar (..), CInt (..), CSize (..))
+import           Foreign.Ptr          (Ptr)
+import           System.IO.Unsafe     (unsafePerformIO)
 import           System.Random        (RandomGen, random)
+
+
+--------------------------------------------------------------------------------
+foreign import ccall unsafe "_hs_mask_chunk" c_mask_chunk
+    :: Word32 -> CInt -> Ptr CChar -> CSize -> IO CInt
 
 
 --------------------------------------------------------------------------------
 -- | ByteString should be exactly 4 bytes long
 type Mask = Maybe B.ByteString
-
-
---------------------------------------------------------------------------------
--- | Apply mask
-maskPayload :: Mask -> BL.ByteString -> BL.ByteString
-maskPayload Nothing = id
-maskPayload (Just "\x00\x00\x00\x00") = id
-maskPayload (Just mask) =
-  BL.fromChunks . go (cycle (B.unpack mask)) . BL.toChunks
-  where
-  go _ [] = []
-  go ms (chunk : chunks) =
-      let (ms', chunk') = B.mapAccumL f ms chunk
-      in chunk' : go ms' chunks
-  f (m : ms) c = (ms, m `xor` c)
-  f [] _ = error "impossible, we have infinite stream of mask bytes"
 
 
 --------------------------------------------------------------------------------
@@ -48,3 +43,41 @@ randomMask gen = (Just (B.pack [b1, b2, b3, b4]), gen')
     !b2           = fromIntegral $ int `shiftR` 8  `mod` 0x100
     !b3           = fromIntegral $ int `shiftR` 16 `mod` 0x100
     !b4           = fromIntegral $ int `shiftR` 24 `mod` 0x100
+
+
+--------------------------------------------------------------------------------
+-- | This is very dangerous because it modifies the contents of the original
+-- bytestring rather than returning a new one.  Use at your own risk.
+maskPayload :: Mask -> BL.ByteString -> BL.ByteString
+maskPayload Nothing                   = id
+maskPayload (Just "\x00\x00\x00\x00") = id
+maskPayload (Just mask)
+    | B.length mask == 4 =
+        BL.fromChunks . unsafePerformIO . go 0 . BL.toChunks
+    | otherwise          =
+        error "Network.WebSockets.Hybi13.Mask: mask length must be 4"
+  where
+    go :: CInt -> [B.ByteString] -> IO [B.ByteString]
+    go _ [] = return []
+    go shift0 (c0 : chunks) = do
+        -- TODO (jaspervdj): this code copies the string twice:
+        --
+        -- - Once in 'B.useAsCStringLen'
+        -- - Once in 'B.packCStringLen'
+        --
+        -- We should be able to get away with one copy and in some cases zero
+        -- copies.
+        (c1, shift1) <- B.useAsCStringLen c0 $ \(ptr, len) -> do
+            shift1 <- c_mask_chunk mask32 shift0 ptr (fromIntegral len)
+            c1     <- B.packCStringLen (ptr, len)
+            return (c1, shift1)
+        (c1 :) <$> go shift1 chunks
+
+    -- | Puts the mask into a 'Word32' in a way that will allow fast masking on
+    -- little-endian platforms.
+    mask32 :: Word32
+    mask32 =
+        (fromIntegral (B.index mask 0) `shiftL`  0) .|.
+        (fromIntegral (B.index mask 1) `shiftL`  8) .|.
+        (fromIntegral (B.index mask 2) `shiftL` 16) .|.
+        (fromIntegral (B.index mask 3) `shiftL` 24)

--- a/src/Network/WebSockets/Server.hs
+++ b/src/Network/WebSockets/Server.hs
@@ -95,7 +95,7 @@ makeListenSocket host port = do
         return sock
         )
   where
-    hints = S.defaultHints { S.addrSocketType = S.Stream }  
+    hints = S.defaultHints { S.addrSocketType = S.Stream }
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/WebSockets/Stream.hs
+++ b/src/Network/WebSockets/Stream.hs
@@ -7,10 +7,12 @@ module Network.WebSockets.Stream
     , makeSocketStream
     , makeEchoStream
     , parse
+    , parseBin
     , write
     , close
     ) where
 
+import qualified Data.Binary.Get                as BIN
 import           Control.Concurrent.MVar        (MVar, newEmptyMVar, newMVar,
                                                  putMVar, takeMVar, withMVar)
 import           Control.Exception              (onException, throwIO)
@@ -124,6 +126,38 @@ makeEchoStream = do
 
 
 --------------------------------------------------------------------------------
+parseBin :: Stream -> BIN.Get a -> IO (Maybe a)
+parseBin stream parser = do
+    state <- readIORef (streamState stream)
+    case state of
+        Closed remainder
+            | B.null remainder -> return Nothing
+            | otherwise        -> go (BIN.runGetIncremental parser `BIN.pushChunk` remainder) True
+        Open buffer
+            | B.null buffer -> do
+                mbBs <- streamIn stream
+                case mbBs of
+                    Nothing -> do
+                        writeIORef (streamState stream) (Closed B.empty)
+                        return Nothing
+                    Just bs -> go (BIN.runGetIncremental parser `BIN.pushChunk` bs) False
+            | otherwise     -> go (BIN.runGetIncremental parser `BIN.pushChunk` buffer) False
+  where
+    -- Buffer is empty when entering this function.
+    go (BIN.Done remainder _ x) closed = do
+        writeIORef (streamState stream) $
+            if closed then Closed remainder else Open remainder
+        return (Just x)
+    go (BIN.Partial f) closed
+        | closed    = go (f Nothing) True
+        | otherwise = do
+            mbBs <- streamIn stream
+            case mbBs of
+                Nothing -> go (f Nothing) True
+                Just bs -> go (f (Just bs)) False
+    go (BIN.Fail _ _ err) _ = throwIO (ParseException err)
+
+
 parse :: Stream -> Atto.Parser a -> IO (Maybe a)
 parse stream parser = do
     state <- readIORef (streamState stream)

--- a/src/Network/WebSockets/Stream.hs
+++ b/src/Network/WebSockets/Stream.hs
@@ -104,7 +104,7 @@ makeSocketStream :: S.Socket -> IO Stream
 makeSocketStream socket = makeStream receive send
   where
     receive = do
-        bs <- SB.recv socket 1024
+        bs <- SB.recv socket 8192
         return $ if B.null bs then Nothing else Just bs
 
     send Nothing   = return ()

--- a/tests/haskell/Network/WebSockets/Mask/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Mask/Tests.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE BangPatterns      #-}
+--------------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+module Network.WebSockets.Mask.Tests
+    ( tests
+    ) where
+
+
+--------------------------------------------------------------------------------
+import qualified Data.Binary.Get                      as BIN
+import           Data.Bits                            (xor)
+import qualified Data.ByteString                      as B
+import qualified Data.ByteString.Lazy                 as BL
+import           Network.WebSockets.Hybi13.Mask
+import           Test.Framework                       (Test, testGroup)
+import           Test.Framework.Providers.QuickCheck2 (testProperty)
+import           Test.QuickCheck                      (Arbitrary (..), (===))
+import qualified Test.QuickCheck                      as QC
+
+import           Network.WebSockets.Tests.Util
+--------------------------------------------------------------------------------
+tests :: Test
+tests = testGroup "Network.WebSockets.Masks.Tests"
+    [ testProperty "correct fast masking" testMasking ]
+
+maskPayload' :: Maybe B.ByteString -> BL.ByteString -> BL.ByteString
+maskPayload' Nothing     = id
+maskPayload' (Just mask) = snd . BL.mapAccumL f (cycle $ B.unpack mask)
+  where
+    f []     !c = ([], c)
+    f (m:ms) !c = (ms, m `xor` c)
+
+newtype AMask = AMask B.ByteString deriving (Show)
+instance Arbitrary AMask where
+  arbitrary = do
+      c1 <- arbitrary
+      c2 <- arbitrary
+      c3 <- arbitrary
+      c4 <- arbitrary
+      return (AMask (B.pack [c1,c2,c3,c4]))
+
+newtype APkt = APkt BL.ByteString deriving (Show)
+instance Arbitrary APkt where
+  arbitrary = do
+    b1 <- arbitraryByteString
+    b2 <- arbitraryByteString
+    return $ APkt (b1 `BL.append` b2) -- Just for sure to test correctly different alignments
+  shrink (APkt bs) =
+      map APkt [ BL.append a b | (a, b) <- zip (BL.inits bs) (tail $ BL.tails bs) ]
+
+testMasking :: QC.Property
+testMasking =
+  QC.forAllShrink QC.arbitrary QC.shrink $ \(AMask mask, APkt pkt) ->
+    let wmask = BIN.runGet BIN.getWord32host (BL.fromStrict mask)
+    in maskPayload' (Just mask) pkt === maskPayload (Just wmask) pkt

--- a/tests/haskell/TestSuite.hs
+++ b/tests/haskell/TestSuite.hs
@@ -2,6 +2,7 @@
 import qualified Network.WebSockets.Extensions.Tests
 import qualified Network.WebSockets.Handshake.Tests
 import qualified Network.WebSockets.Http.Tests
+import qualified Network.WebSockets.Mask.Tests
 import qualified Network.WebSockets.Server.Tests
 import qualified Network.WebSockets.Tests
 import           Test.Framework                      (defaultMain)
@@ -14,5 +15,6 @@ main = defaultMain
     , Network.WebSockets.Handshake.Tests.tests
     , Network.WebSockets.Http.Tests.tests
     , Network.WebSockets.Server.Tests.tests
+    , Network.WebSockets.Mask.Tests.tests
     , Network.WebSockets.Tests.tests
     ]

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -199,6 +199,7 @@ Executable websockets-autobahn
 Benchmark bench-mask
     type:       exitcode-stdio-1.0
     main-is:    mask.hs
+    C-sources:      cbits/cbits.c
     hs-source-dirs: benchmarks, src
     build-depends:
         base,

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -51,6 +51,7 @@ Flag Example
 Library
   Hs-source-dirs: src
   Ghc-options:    -Wall
+  C-sources:      cbits/cbits.c
 
   Exposed-modules:
     Network.WebSockets
@@ -93,6 +94,7 @@ Test-suite websockets-tests
   Hs-source-dirs: src tests/haskell
   Main-is:        TestSuite.hs
   Ghc-options:    -Wall
+  C-sources:      cbits/cbits.c
 
   Other-modules:
     Network.WebSockets

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -111,6 +111,7 @@ Test-suite websockets-tests
     Network.WebSockets.Hybi13
     Network.WebSockets.Hybi13.Demultiplex
     Network.WebSockets.Hybi13.Mask
+    Network.WebSockets.Mask.Tests
     Network.WebSockets.Protocol
     Network.WebSockets.Server
     Network.WebSockets.Server.Tests
@@ -206,3 +207,4 @@ Benchmark bench-mask
         bytestring,
         criterion,
         random
+    other-modules:  Network.WebSockets.Hybi13.Mask


### PR DESCRIPTION
This is a merge against the fast-mask branch.

- Changed mask to be `Word32`
- Changed the frame parser to use `binary`
- Changed blocksize on received data to 8192
- Fixed C-code, changed it to do just 1 copy
- Added quickcheck for the masking code

It seems to me there are still some unnecessary bytestrings in memory, but it is some fixed memory per connection (~ 15K), it doesn't seem to change depending on the traffic on the socket.