### PR TITLE
Fix reason phrase parsing

### DIFF
--- a/src/Network/WebSockets/Http.hs
+++ b/src/Network/WebSockets/Http.hs
@@ -195,7 +195,7 @@ decodeResponseHead = ResponseHead
     newline = A.string "\r\n"
 
     code = A.string "HTTP/1.1" *> space *> A.takeWhile1 (/= c2w ' ') <* space
-    message = A.takeWhile1 (/= c2w '\r') <* newline
+    message = A.takeWhile (/= c2w '\r') <* newline
 
 
 --------------------------------------------------------------------------------

--- a/tests/haskell/Network/WebSockets/Http/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Http/Tests.hs
@@ -22,6 +22,7 @@ tests :: Test
 tests = testGroup "Network.WebSockets.Http.Tests"
     [ testCase "jwebsockets response" jWebSocketsResponse
     , testCase "chromium response"    chromiumResponse
+    , testCase "matchbook response"   matchbookResponse
     ]
 
 
@@ -58,4 +59,30 @@ chromiumResponse = assert $ case A.parseOnly decodeResponseHead input of
         , "Content-Length:23"
         , ""
         , "No such target id: 20_1"
+        ]
+
+--------------------------------------------------------------------------------
+-- | This is a specific response sent by Matchbook.com which caused trouble
+
+matchbookResponse :: Assertion
+matchbookResponse = assert $ case A.parseOnly decodeResponseHead input of
+    Left err -> error err
+    Right _  -> True
+  where
+    input = BC.intercalate "\r\n"
+        [ "HTTP/1.1 101 "
+        , "Date: Mon, 22 May 2017 19:39:08 GMT"
+        , "Connection: upgrade"
+        , "Set-Cookie: __cfduid=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdea; expires=Tue, 22-May-18 19:39:08 GMT; path=/; domain=.matchbook.com; HttpOnly"
+        , "X-Content-Type-Options: nosniff"
+        , "X-XSS-Protection: 1; mode=block"
+        , "X-Frame-Options: DENY"
+        , "Upgrade: websocket"
+        , "Sec-WebSocket-Accept: dEadB33fDeadbEEfD3aDbE3Fdea="
+        , "X-MB-HA: edge-socket"
+        , "X-MB-HAP: haproxy01aws"
+        , "Server: cloudflare-nginx"
+        , "CF-RAY: 3632deadbeef5b33-HEL"
+        , ""
+        , ""
         ]


### PR DESCRIPTION
This PR fixes the parsing of the message or "reason-phrase" part of the response status line. According to [the specification](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html) it is allowed to be empty while the library required it to have non-zero width. Please see, for example, [this SO thread](https://stackoverflow.com/q/17517086/8051150) for discussion.