### PR TITLE
Add limit options for frame and message size

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -26,8 +26,7 @@ module Network.WebSockets
     , defaultPermessageDeflate
 
       -- ** Protection limits
-    , FramePayloadSizeLimit (..)
-    , MessageDataSizeLimit (..)
+    , SizeLimit (..)
 
       -- * Sending and receiving messages
     , receive

--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -25,6 +25,10 @@ module Network.WebSockets
     , PermessageDeflate (..)
     , defaultPermessageDeflate
 
+      -- ** Protection limits
+    , FrameSizeLimit (..)
+    , MessageDataSizeLimit (..)
+
       -- * Sending and receiving messages
     , receive
     , receiveDataMessage

--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -26,7 +26,7 @@ module Network.WebSockets
     , defaultPermessageDeflate
 
       -- ** Protection limits
-    , FrameSizeLimit (..)
+    , FramePayloadSizeLimit (..)
     , MessageDataSizeLimit (..)
 
       -- * Sending and receiving messages

--- a/src/Network/WebSockets/Client.hs
+++ b/src/Network/WebSockets/Client.hs
@@ -103,7 +103,7 @@ runClientWithStream stream host path opts customHeaders app = do
             "response from server"
     void $ either throwIO return $ finishResponse protocol request response
     parse   <- decodeMessages protocol
-                (connectionFrameSizeLimit opts)
+                (connectionFramePayloadSizeLimit opts)
                 (connectionMessageDataSizeLimit opts) stream
     write   <- encodeMessages protocol ClientConnection stream
     sentRef <- newIORef False

--- a/src/Network/WebSockets/Client.hs
+++ b/src/Network/WebSockets/Client.hs
@@ -102,9 +102,11 @@ runClientWithStream stream host path opts customHeaders app = do
             "Network.WebSockets.Client.runClientWithStream: no handshake " ++
             "response from server"
     void $ either throwIO return $ finishResponse protocol request response
-    parse        <- decodeMessages protocol stream
-    write        <- encodeMessages protocol ClientConnection stream
-    sentRef      <- newIORef False
+    parse   <- decodeMessages protocol
+                (connectionFrameSizeLimit opts)
+                (connectionMessageDataSizeLimit opts) stream
+    write   <- encodeMessages protocol ClientConnection stream
+    sentRef <- newIORef False
 
     app Connection
         { connectionOptions   = opts

--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -38,7 +38,7 @@ module Network.WebSockets.Connection
     , PermessageDeflate (..)
     , defaultPermessageDeflate
 
-    , FrameSizeLimit (..)
+    , FramePayloadSizeLimit (..)
     , MessageDataSizeLimit (..)
     ) where
 
@@ -168,7 +168,7 @@ acceptRequestWith pc ar = case find (flip compatible request) protocols of
 
         parseRaw <- decodeMessages
             protocol
-            (connectionFrameSizeLimit options)
+            (connectionFramePayloadSizeLimit options)
             (connectionMessageDataSizeLimit options)
             (pendingStream pc)
         writeRaw <- encodeMessages protocol ServerConnection (pendingStream pc)

--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -38,8 +38,7 @@ module Network.WebSockets.Connection
     , PermessageDeflate (..)
     , defaultPermessageDeflate
 
-    , FramePayloadSizeLimit (..)
-    , MessageDataSizeLimit (..)
+    , SizeLimit (..)
     ) where
 
 

--- a/src/Network/WebSockets/Connection/Options.hs
+++ b/src/Network/WebSockets/Connection/Options.hs
@@ -1,0 +1,103 @@
+--------------------------------------------------------------------------------
+module Network.WebSockets.Connection.Options
+    ( ConnectionOptions (..)
+    , defaultConnectionOptions
+
+    , CompressionOptions (..)
+    , PermessageDeflate (..)
+    , defaultPermessageDeflate
+
+    , FrameSizeLimit (..)
+    , MessageDataSizeLimit (..)
+    ) where
+
+
+--------------------------------------------------------------------------------
+import           Data.Int (Int64)
+
+
+--------------------------------------------------------------------------------
+-- | Set options for a 'Connection'.
+data ConnectionOptions = ConnectionOptions
+    { connectionOnPong               :: !(IO ())
+      -- ^ Whenever a 'pong' is received, this IO action is executed. It can be
+      -- used to tickle connections or fire missiles.
+    , connectionCompressionOptions   :: !CompressionOptions
+      -- ^ Enable 'PermessageDeflate'.
+    , connectionStrictUnicode        :: !Bool
+      -- ^ Enable strict unicode on the connection.  This means that if a client
+      -- (or server) sends invalid UTF-8, we will throw a 'UnicodeException'
+      -- rather than replacing it by the unicode replacement character U+FFFD.
+    , connectionFrameSizeLimit       :: !FrameSizeLimit
+      -- ^ The maximum size for incoming frames, in bytes.  If a frame exceeds
+      -- this limit, a 'ParseException' is thrown.
+    , connectionMessageDataSizeLimit :: !MessageDataSizeLimit
+      -- ^ 'connectionFrameSizeLimit' is often not enough since a malicious
+      -- client can send many small frames to create a huge message.  This limit
+      -- allows you to protect from that.  If a message exceeds this limit, a
+      -- 'ParseException' is thrown.
+      --
+      -- Note that, if compression is enabled, we check the size of the
+      -- compressed messages, as well as the size of the uncompressed messages
+      -- as we are deflating them to ensure we don't use too much memory in any
+      -- case.
+    }
+
+
+--------------------------------------------------------------------------------
+-- | The default connection options:
+--
+-- * Nothing happens when a pong is received.
+-- * Compression is disabled.
+-- * Lenient unicode decoding.
+defaultConnectionOptions :: ConnectionOptions
+defaultConnectionOptions = ConnectionOptions
+    { connectionOnPong               = return ()
+    , connectionCompressionOptions   = NoCompression
+    , connectionStrictUnicode        = False
+    , connectionFrameSizeLimit       = NoFrameSizeLimit
+    , connectionMessageDataSizeLimit = NoMessageDataSizeLimit
+    }
+
+
+--------------------------------------------------------------------------------
+data CompressionOptions
+    = NoCompression
+    | PermessageDeflateCompression PermessageDeflate
+    deriving (Eq, Show)
+
+
+--------------------------------------------------------------------------------
+-- | Four extension parameters are defined for "permessage-deflate" to
+-- help endpoints manage per-connection resource usage.
+--
+-- - "server_no_context_takeover"
+-- - "client_no_context_takeover"
+-- - "server_max_window_bits"
+-- - "client_max_window_bits"
+data PermessageDeflate = PermessageDeflate
+    { serverNoContextTakeover :: Bool
+    , clientNoContextTakeover :: Bool
+    , serverMaxWindowBits     :: Int
+    , clientMaxWindowBits     :: Int
+    , pdCompressionLevel      :: Int
+    } deriving (Eq, Show)
+
+
+--------------------------------------------------------------------------------
+defaultPermessageDeflate :: PermessageDeflate
+defaultPermessageDeflate = PermessageDeflate False False 15 15 8
+
+
+--------------------------------------------------------------------------------
+data FrameSizeLimit
+    = NoFrameSizeLimit
+    | FrameSizeLimit !Int64
+    deriving (Eq, Show)
+
+
+--------------------------------------------------------------------------------
+data MessageDataSizeLimit
+    = NoMessageDataSizeLimit
+    | MessageDataSizeLimit !Int64
+    deriving (Eq, Show)

--- a/src/Network/WebSockets/Connection/Options.hs
+++ b/src/Network/WebSockets/Connection/Options.hs
@@ -7,7 +7,7 @@ module Network.WebSockets.Connection.Options
     , PermessageDeflate (..)
     , defaultPermessageDeflate
 
-    , FrameSizeLimit (..)
+    , FramePayloadSizeLimit (..)
     , MessageDataSizeLimit (..)
     ) where
 
@@ -19,19 +19,19 @@ import           Data.Int (Int64)
 --------------------------------------------------------------------------------
 -- | Set options for a 'Connection'.
 data ConnectionOptions = ConnectionOptions
-    { connectionOnPong               :: !(IO ())
+    { connectionOnPong                :: !(IO ())
       -- ^ Whenever a 'pong' is received, this IO action is executed. It can be
       -- used to tickle connections or fire missiles.
-    , connectionCompressionOptions   :: !CompressionOptions
+    , connectionCompressionOptions    :: !CompressionOptions
       -- ^ Enable 'PermessageDeflate'.
-    , connectionStrictUnicode        :: !Bool
+    , connectionStrictUnicode         :: !Bool
       -- ^ Enable strict unicode on the connection.  This means that if a client
       -- (or server) sends invalid UTF-8, we will throw a 'UnicodeException'
       -- rather than replacing it by the unicode replacement character U+FFFD.
-    , connectionFrameSizeLimit       :: !FrameSizeLimit
-      -- ^ The maximum size for incoming frames, in bytes.  If a frame exceeds
-      -- this limit, a 'ParseException' is thrown.
-    , connectionMessageDataSizeLimit :: !MessageDataSizeLimit
+    , connectionFramePayloadSizeLimit :: !FramePayloadSizeLimit
+      -- ^ The maximum size for incoming frame payload size in bytes.  If a
+      -- frame exceeds this limit, a 'ParseException' is thrown.
+    , connectionMessageDataSizeLimit  :: !MessageDataSizeLimit
       -- ^ 'connectionFrameSizeLimit' is often not enough since a malicious
       -- client can send many small frames to create a huge message.  This limit
       -- allows you to protect from that.  If a message exceeds this limit, a
@@ -55,7 +55,7 @@ defaultConnectionOptions = ConnectionOptions
     { connectionOnPong               = return ()
     , connectionCompressionOptions   = NoCompression
     , connectionStrictUnicode        = False
-    , connectionFrameSizeLimit       = NoFrameSizeLimit
+    , connectionFramePayloadSizeLimit       = NoFramePayloadSizeLimit
     , connectionMessageDataSizeLimit = NoMessageDataSizeLimit
     }
 
@@ -90,9 +90,9 @@ defaultPermessageDeflate = PermessageDeflate False False 15 15 8
 
 
 --------------------------------------------------------------------------------
-data FrameSizeLimit
-    = NoFrameSizeLimit
-    | FrameSizeLimit !Int64
+data FramePayloadSizeLimit
+    = NoFramePayloadSizeLimit
+    | FramePayloadSizeLimit !Int64
     deriving (Eq, Show)
 
 

--- a/src/Network/WebSockets/Hybi13.hs
+++ b/src/Network/WebSockets/Hybi13.hs
@@ -159,7 +159,7 @@ encodeFrame mask f = B.fromWord8 byte0 `mappend`
 
 --------------------------------------------------------------------------------
 decodeMessages
-    :: FrameSizeLimit
+    :: FramePayloadSizeLimit
     -> MessageDataSizeLimit
     -> Stream
     -> IO (IO (Maybe Message))
@@ -182,7 +182,7 @@ decodeMessages frameLimit messageLimit stream = do
 
 --------------------------------------------------------------------------------
 -- | Parse a frame
-parseFrame :: FrameSizeLimit -> Get Frame
+parseFrame :: FramePayloadSizeLimit -> Get Frame
 parseFrame frameSizeLimit = do
     byte0 <- getWord8
     let fin    = byte0 .&. 0x80 == 0x80
@@ -202,10 +202,10 @@ parseFrame frameSizeLimit = do
 
     -- Check size against limit.
     case frameSizeLimit of
-        NoFrameSizeLimit           -> return ()
-        FrameSizeLimit n | len > n -> fail $
+        NoFramePayloadSizeLimit           -> return ()
+        FramePayloadSizeLimit n | len > n -> fail $
             "Frame of size " ++ show len ++ " exceeded limit"
-        FrameSizeLimit _           -> return ()
+        FramePayloadSizeLimit _           -> return ()
 
     ft <- case opcode of
         0x00 -> return ContinuationFrame

--- a/src/Network/WebSockets/Protocol.hs
+++ b/src/Network/WebSockets/Protocol.hs
@@ -79,7 +79,7 @@ encodeMessages Hybi13 = Hybi13.encodeMessages
 --------------------------------------------------------------------------------
 decodeMessages
     :: Protocol
-    -> FrameSizeLimit -> MessageDataSizeLimit
+    -> FramePayloadSizeLimit -> MessageDataSizeLimit
     -> Stream
     -> IO (IO (Maybe Message))
 decodeMessages Hybi13 frameLimit messageLimit =

--- a/src/Network/WebSockets/Protocol.hs
+++ b/src/Network/WebSockets/Protocol.hs
@@ -16,14 +16,15 @@ module Network.WebSockets.Protocol
 
 
 --------------------------------------------------------------------------------
-import           Data.ByteString           (ByteString)
-import qualified Data.ByteString           as B
+import           Data.ByteString                       (ByteString)
+import qualified Data.ByteString                       as B
 
 
 --------------------------------------------------------------------------------
+import           Network.WebSockets.Connection.Options
 import           Network.WebSockets.Http
-import qualified Network.WebSockets.Hybi13 as Hybi13
-import           Network.WebSockets.Stream (Stream)
+import qualified Network.WebSockets.Hybi13             as Hybi13
+import           Network.WebSockets.Stream             (Stream)
 import           Network.WebSockets.Types
 
 
@@ -77,9 +78,12 @@ encodeMessages Hybi13 = Hybi13.encodeMessages
 
 --------------------------------------------------------------------------------
 decodeMessages
-    :: Protocol -> Stream
+    :: Protocol
+    -> FrameSizeLimit -> MessageDataSizeLimit
+    -> Stream
     -> IO (IO (Maybe Message))
-decodeMessages Hybi13 = Hybi13.decodeMessages
+decodeMessages Hybi13 frameLimit messageLimit =
+    Hybi13.decodeMessages frameLimit messageLimit
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/WebSockets/Protocol.hs
+++ b/src/Network/WebSockets/Protocol.hs
@@ -78,9 +78,7 @@ encodeMessages Hybi13 = Hybi13.encodeMessages
 
 --------------------------------------------------------------------------------
 decodeMessages
-    :: Protocol
-    -> FramePayloadSizeLimit -> MessageDataSizeLimit
-    -> Stream
+    :: Protocol -> SizeLimit -> SizeLimit -> Stream
     -> IO (IO (Maybe Message))
 decodeMessages Hybi13 frameLimit messageLimit =
     Hybi13.decodeMessages frameLimit messageLimit

--- a/src/Network/WebSockets/Types.hs
+++ b/src/Network/WebSockets/Types.hs
@@ -160,7 +160,7 @@ data ConnectionException
     -- | The client sent invalid UTF-8.  Note that this exception will only be
     -- thrown if strict decoding is set in the connection options.
     | UnicodeException String
-    deriving (Show, Typeable)
+    deriving (Eq, Show, Typeable)
 
 
 --------------------------------------------------------------------------------

--- a/tests/haskell/Network/WebSockets/Extensions/PermessageDeflate/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Extensions/PermessageDeflate/Tests.hs
@@ -1,0 +1,46 @@
+--------------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+module Network.WebSockets.Extensions.PermessageDeflate.Tests
+    ( tests
+    ) where
+
+
+--------------------------------------------------------------------------------
+import           Control.Exception                               (try)
+import qualified Data.ByteString.Lazy                            as BL
+import           Network.WebSockets.Extensions.PermessageDeflate
+import           Network.WebSockets.Types
+import           Network.WebSockets.Connection.Options
+import           Test.Framework                                  (Test,
+                                                                  testGroup)
+import           Test.Framework.Providers.HUnit                  (testCase)
+import           Test.HUnit                                      (Assertion,
+                                                                  (@?=))
+
+
+--------------------------------------------------------------------------------
+tests :: Test
+tests = testGroup "Network.WebSockets.Extensions.PermessageDeflate.Tests"
+    [ testCase "OK 1" $ do
+        inflater <- makeMessageInflater
+            (MessageDataSizeLimit 100) (Just defaultPermessageDeflate)
+        message <- inflater $ DataMessage True False False (Binary deflated100)
+        message @?=
+            DataMessage False False False (Binary inflated100)
+    , testCase "Exceed 1" $ do
+        inflater <- makeMessageInflater
+            (MessageDataSizeLimit 99) (Just defaultPermessageDeflate)
+        assertParseException $
+            inflater $ DataMessage True False False (Binary deflated100)
+    ]
+  where
+    assertParseException :: IO a -> Assertion
+    assertParseException io = do
+        errOrX <- try io
+        case errOrX of
+            Left (ParseException _) -> return ()
+            _                       -> fail "Excepted ParseException"
+
+    -- This inflates to 100 bytes.
+    deflated100 = "b`\160=\NUL\NUL"
+    inflated100 = BL.replicate 100 0

--- a/tests/haskell/Network/WebSockets/Extensions/PermessageDeflate/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Extensions/PermessageDeflate/Tests.hs
@@ -23,13 +23,13 @@ tests :: Test
 tests = testGroup "Network.WebSockets.Extensions.PermessageDeflate.Tests"
     [ testCase "OK 1" $ do
         inflater <- makeMessageInflater
-            (MessageDataSizeLimit 100) (Just defaultPermessageDeflate)
+            (SizeLimit 100) (Just defaultPermessageDeflate)
         message <- inflater $ DataMessage True False False (Binary deflated100)
         message @?=
             DataMessage False False False (Binary inflated100)
     , testCase "Exceed 1" $ do
         inflater <- makeMessageInflater
-            (MessageDataSizeLimit 99) (Just defaultPermessageDeflate)
+            (SizeLimit 99) (Just defaultPermessageDeflate)
         assertParseException $
             inflater $ DataMessage True False False (Binary deflated100)
     ]

--- a/tests/haskell/Network/WebSockets/Hybi13/Demultiplex/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Hybi13/Demultiplex/Tests.hs
@@ -28,19 +28,19 @@ testMessageDataSizeLimit :: Test
 testMessageDataSizeLimit = testGroup "testMessageDataSizeLimit Hybi13"
     [ testCase "OK 1" $
         Right [DataMessage False False False (Binary (mkZeroes 100))] @=?
-        testDemultiplex (MessageDataSizeLimit 100) (fragmented 5 20)
+        testDemultiplex (SizeLimit 100) (fragmented 5 20)
     , testCase "Exceeds 1" $
         assertLeft $
-        testDemultiplex (MessageDataSizeLimit 99) (fragmented 5 20)
+        testDemultiplex (SizeLimit 99) (fragmented 5 20)
     , testCase "Exceeds 2" $
         assertLeft $
-        testDemultiplex (MessageDataSizeLimit 100) (fragmented 6 20)
+        testDemultiplex (SizeLimit 100) (fragmented 6 20)
     , testCase "Exceeds 3" $
         assertLeft $
-        testDemultiplex (MessageDataSizeLimit 100) (fragmented 101 1)
+        testDemultiplex (SizeLimit 100) (fragmented 101 1)
     , testCase "Exceeds 4" $
         assertLeft $
-        testDemultiplex (MessageDataSizeLimit 100) (fragmented 1 101)
+        testDemultiplex (SizeLimit 100) (fragmented 1 101)
     ]
   where
     fragmented :: Int -> Int -> [Frame]
@@ -60,7 +60,7 @@ testMessageDataSizeLimit = testGroup "testMessageDataSizeLimit Hybi13"
 
 --------------------------------------------------------------------------------
 testDemultiplex
-    :: MessageDataSizeLimit
+    :: SizeLimit
     -> [Frame]
     -> Either ConnectionException [Message]
 testDemultiplex messageLimit = go emptyDemultiplexState

--- a/tests/haskell/Network/WebSockets/Hybi13/Demultiplex/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Hybi13/Demultiplex/Tests.hs
@@ -1,0 +1,72 @@
+--------------------------------------------------------------------------------
+{-# LANGUAGE OverloadedStrings #-}
+module Network.WebSockets.Hybi13.Demultiplex.Tests
+    ( tests
+    ) where
+
+
+--------------------------------------------------------------------------------
+import           Control.Applicative                   ((<$>))
+import qualified Data.ByteString.Lazy                  as BL
+import           Network.WebSockets
+import           Network.WebSockets.Hybi13.Demultiplex
+import           Prelude
+import           Test.Framework                        (Test, testGroup)
+import           Test.Framework.Providers.HUnit        (testCase)
+import           Test.HUnit                            (Assertion, (@=?))
+
+
+--------------------------------------------------------------------------------
+tests :: Test
+tests = testGroup "Network.WebSockets.Hybi13.Demultiplex.Tests"
+    [ testMessageDataSizeLimit
+    ]
+
+
+--------------------------------------------------------------------------------
+testMessageDataSizeLimit :: Test
+testMessageDataSizeLimit = testGroup "testMessageDataSizeLimit Hybi13"
+    [ testCase "OK 1" $
+        Right [DataMessage False False False (Binary (mkZeroes 100))] @=?
+        testDemultiplex (MessageDataSizeLimit 100) (fragmented 5 20)
+    , testCase "Exceeds 1" $
+        assertLeft $
+        testDemultiplex (MessageDataSizeLimit 99) (fragmented 5 20)
+    , testCase "Exceeds 2" $
+        assertLeft $
+        testDemultiplex (MessageDataSizeLimit 100) (fragmented 6 20)
+    , testCase "Exceeds 3" $
+        assertLeft $
+        testDemultiplex (MessageDataSizeLimit 100) (fragmented 101 1)
+    , testCase "Exceeds 4" $
+        assertLeft $
+        testDemultiplex (MessageDataSizeLimit 100) (fragmented 1 101)
+    ]
+  where
+    fragmented :: Int -> Int -> [Frame]
+    fragmented n size =
+        let payload = mkZeroes size in
+        [Frame False False False False BinaryFrame payload] ++
+        replicate (n - 2) (Frame False False False False ContinuationFrame payload) ++
+        [Frame True False False False ContinuationFrame payload]
+
+    mkZeroes :: Int -> BL.ByteString
+    mkZeroes size = BL.replicate (fromIntegral size) 0
+
+    assertLeft :: Either a b -> Assertion
+    assertLeft (Left _)  = return ()
+    assertLeft (Right _) = fail "Expecting test to fail"
+
+
+--------------------------------------------------------------------------------
+testDemultiplex
+    :: MessageDataSizeLimit
+    -> [Frame]
+    -> Either ConnectionException [Message]
+testDemultiplex messageLimit = go emptyDemultiplexState
+  where
+    go _state0 []               = return []
+    go state0  (frame : frames) = case demultiplex messageLimit state0 frame of
+        (DemultiplexContinue, state1)  -> go state1 frames
+        (DemultiplexError err, _)      -> Left err
+        (DemultiplexSuccess m, state1) -> (m :) <$> go state1 frames

--- a/tests/haskell/Network/WebSockets/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Tests.hs
@@ -11,12 +11,18 @@ import qualified Blaze.ByteString.Builder              as Builder
 import           Control.Applicative                   ((<$>))
 import           Control.Concurrent                    (forkIO)
 import           Control.Exception                     (try)
-import           Control.Monad                         (forM_, replicateM)
+import           Control.Monad                         (replicateM)
 import           Data.Binary.Get                       (runGetOrFail)
 import qualified Data.ByteString.Lazy                  as BL
 import           Data.List                             (intersperse)
 import           Data.Maybe                            (catMaybes)
-import           System.Random                         (mkStdGen)
+import           Network.WebSockets
+import qualified Network.WebSockets.Hybi13             as Hybi13
+import           Network.WebSockets.Hybi13.Demultiplex
+import           Network.WebSockets.Protocol
+import qualified Network.WebSockets.Stream             as Stream
+import           Network.WebSockets.Tests.Util
+import           Network.WebSockets.Types
 import           Test.Framework                        (Test, testGroup)
 import           Test.Framework.Providers.HUnit        (testCase)
 import           Test.Framework.Providers.QuickCheck2  (testProperty)
@@ -25,16 +31,7 @@ import           Test.QuickCheck                       (Arbitrary (..), Gen,
                                                         Property)
 import qualified Test.QuickCheck                       as QC
 import qualified Test.QuickCheck.Monadic               as QC
-
-
---------------------------------------------------------------------------------
-import           Network.WebSockets
-import qualified Network.WebSockets.Hybi13             as Hybi13
-import           Network.WebSockets.Hybi13.Demultiplex
-import           Network.WebSockets.Protocol
-import qualified Network.WebSockets.Stream             as Stream
-import           Network.WebSockets.Tests.Util
-import           Network.WebSockets.Types
+import           Prelude
 
 
 --------------------------------------------------------------------------------
@@ -51,7 +48,7 @@ testSimpleEncodeDecode :: Protocol -> Property
 testSimpleEncodeDecode protocol = QC.monadicIO $
     QC.forAllM QC.arbitrary $ \msgs -> QC.run $ do
         echo  <- Stream.makeEchoStream
-        parse <- decodeMessages protocol echo
+        parse <- decodeMessages protocol NoFrameSizeLimit NoMessageDataSizeLimit echo
         write <- encodeMessages protocol ClientConnection echo
         _     <- forkIO $ write msgs
         msgs' <- catMaybes <$> replicateM (length msgs) parse
@@ -64,7 +61,7 @@ testFragmentedHybi13 :: Property
 testFragmentedHybi13 = QC.monadicIO $
     QC.forAllM QC.arbitrary $ \fragmented -> QC.run $ do
         echo     <- Stream.makeEchoStream
-        parse    <- Hybi13.decodeMessages echo
+        parse    <- Hybi13.decodeMessages NoFrameSizeLimit NoMessageDataSizeLimit echo
         -- is'      <- Streams.filter isDataMessage =<< Hybi13.decodeMessages is
 
         -- Simple hacky encoding of all frames
@@ -111,7 +108,7 @@ testRfc_6455_5_5_1 =
 testRfc_6455_5_5_2 :: Test
 testRfc_6455_5_5_2 =
     testCase "RFC 6455, 5.5: Frame decoder shall fail if control frame payload length > 125 bytes" $
-        Left (BL.drop 4 ping126, 4, errMsg) @=? runGetOrFail Hybi13.parseFrame ping126
+        Left (BL.drop 4 ping126, 4, errMsg) @=? runGetOrFail (Hybi13.parseFrame NoFrameSizeLimit) ping126
     where
         errMsg = "Control Frames must not carry payload > 125 bytes!"
         ping126 = mconcat

--- a/tests/haskell/TestSuite.hs
+++ b/tests/haskell/TestSuite.hs
@@ -1,5 +1,6 @@
 --------------------------------------------------------------------------------
 import qualified Network.WebSockets.Extensions.Tests
+import qualified Network.WebSockets.Extensions.PermessageDeflate.Tests
 import qualified Network.WebSockets.Handshake.Tests
 import qualified Network.WebSockets.Http.Tests
 import qualified Network.WebSockets.Hybi13.Demultiplex.Tests
@@ -13,6 +14,7 @@ import           Test.Framework                              (defaultMain)
 main :: IO ()
 main = defaultMain
     [ Network.WebSockets.Extensions.Tests.tests
+    , Network.WebSockets.Extensions.PermessageDeflate.Tests.tests
     , Network.WebSockets.Handshake.Tests.tests
     , Network.WebSockets.Http.Tests.tests
     , Network.WebSockets.Hybi13.Demultiplex.Tests.tests

--- a/tests/haskell/TestSuite.hs
+++ b/tests/haskell/TestSuite.hs
@@ -2,10 +2,11 @@
 import qualified Network.WebSockets.Extensions.Tests
 import qualified Network.WebSockets.Handshake.Tests
 import qualified Network.WebSockets.Http.Tests
+import qualified Network.WebSockets.Hybi13.Demultiplex.Tests
 import qualified Network.WebSockets.Mask.Tests
 import qualified Network.WebSockets.Server.Tests
 import qualified Network.WebSockets.Tests
-import           Test.Framework                      (defaultMain)
+import           Test.Framework                              (defaultMain)
 
 
 --------------------------------------------------------------------------------
@@ -14,6 +15,7 @@ main = defaultMain
     [ Network.WebSockets.Extensions.Tests.tests
     , Network.WebSockets.Handshake.Tests.tests
     , Network.WebSockets.Http.Tests.tests
+    , Network.WebSockets.Hybi13.Demultiplex.Tests.tests
     , Network.WebSockets.Server.Tests.tests
     , Network.WebSockets.Mask.Tests.tests
     , Network.WebSockets.Tests.tests

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -112,6 +112,7 @@ Test-suite websockets-tests
     Network.WebSockets.Http.Tests
     Network.WebSockets.Hybi13
     Network.WebSockets.Hybi13.Demultiplex
+    Network.WebSockets.Hybi13.Demultiplex.Tests
     Network.WebSockets.Hybi13.Mask
     Network.WebSockets.Mask.Tests
     Network.WebSockets.Protocol

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -105,6 +105,7 @@ Test-suite websockets-tests
     Network.WebSockets.Extensions
     Network.WebSockets.Extensions.Description
     Network.WebSockets.Extensions.PermessageDeflate
+    Network.WebSockets.Extensions.PermessageDeflate.Tests
     Network.WebSockets.Extensions.StrictUnicode
     Network.WebSockets.Extensions.Tests
     Network.WebSockets.Handshake.Tests

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -101,6 +101,7 @@ Test-suite websockets-tests
     Network.WebSockets
     Network.WebSockets.Client
     Network.WebSockets.Connection
+    Network.WebSockets.Connection.Options
     Network.WebSockets.Extensions
     Network.WebSockets.Extensions.Description
     Network.WebSockets.Extensions.PermessageDeflate

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -62,6 +62,7 @@ Library
 
   Other-modules:
     Network.WebSockets.Client
+    Network.WebSockets.Connection.Options
     Network.WebSockets.Extensions.Description
     Network.WebSockets.Extensions.PermessageDeflate
     Network.WebSockets.Extensions.StrictUnicode


### PR DESCRIPTION
This allows you to set limits for the frame and message sizes to prevent (D)DoS attacks.

See also #149 