### PR TITLE
Use strict atomicModifyIORef'.

### DIFF
--- a/src/Network/WebSockets/Hybi13.hs
+++ b/src/Network/WebSockets/Hybi13.hs
@@ -114,7 +114,7 @@ encodeMessages conType stream = do
     genRef <- newIORef =<< newStdGen
     return $ \msgs -> do
         builders <- forM msgs $ \msg ->
-          atomicModifyIORef genRef $ \s -> encodeMessage conType s msg
+          atomicModifyIORef' genRef $ \s -> encodeMessage conType s msg
         Stream.write stream (B.toLazyByteString $ mconcat builders)
 
 

--- a/src/Network/WebSockets/Stream.hs
+++ b/src/Network/WebSockets/Stream.hs
@@ -20,7 +20,7 @@ import           Control.Monad                  (forM_, when)
 import qualified Data.Attoparsec.ByteString     as Atto
 import qualified Data.ByteString                as B
 import qualified Data.ByteString.Lazy           as BL
-import           Data.IORef                     (IORef, atomicModifyIORef,
+import           Data.IORef                     (IORef, atomicModifyIORef',
                                                  newIORef, readIORef,
                                                  writeIORef)
 import qualified Network.Socket                 as S
@@ -75,7 +75,7 @@ makeStream receive send = do
     return $ Stream (receive' ref receiveLock) (send' ref sendLock) ref
   where
     closeRef :: IORef StreamState -> IO ()
-    closeRef ref = atomicModifyIORef ref $ \state -> case state of
+    closeRef ref = atomicModifyIORef' ref $ \state -> case state of
         Open   buf -> (Closed buf, ())
         Closed buf -> (Closed buf, ())
 


### PR DESCRIPTION
There seems to be a space leak related to the use of `atomicModifyIORef` (i.e. the non-strict variant) in the context of encoding messages in [Network.WebSockets.Hybi13](https://github.com/jaspervdj/websockets/blob/master/src/Network/WebSockets/Hybi13.hs#L92-L118). Specifically, in a server application, it appears that `gen'` is never forced, thus building up a chain of thunks during the lifetime of a connection as messages are sent by the server. The following results are from a test setup with 1000 clients sending a ping every second (to which the server responds with a pong) for a duration of 5 minutes. I also attached the complete sample project, just in case.

`atomicModifyIORef`
![websockets-leak-server-1](https://user-images.githubusercontent.com/177309/28076378-d2e4162a-665e-11e7-9d42-d3cb7dc8d44a.png)

`atomicModifyIORef'`
![websockets-leak-server-2](https://user-images.githubusercontent.com/177309/28076499-36b88884-665f-11e7-9347-94d788615562.png)

Sources: 
[websockets-leak.zip](https://github.com/jaspervdj/websockets/files/1139427/websockets-leak.zip)

I replaced a second occurrence of `atomicModifyIORef` with the strict variant, though seemingly unrelated to this issue.

May be related to https://github.com/jaspervdj/websockets/issues/72
