### PR TITLE
Fix some compatibility issues with old GHC versions

### DIFF
--- a/src/Network/WebSockets/Extensions/Description.hs
+++ b/src/Network/WebSockets/Extensions/Description.hs
@@ -14,7 +14,7 @@ import           Control.Applicative              ((*>), (<*))
 import qualified Data.Attoparsec.ByteString       as A
 import qualified Data.Attoparsec.ByteString.Char8 as AC8
 import qualified Data.ByteString                  as B
-import           Data.Monoid                      (mconcat, (<>))
+import           Data.Monoid                      (mconcat, mappend)
 import           Prelude
 
 type ExtensionParam = (B.ByteString, Maybe B.ByteString)
@@ -48,10 +48,10 @@ parseExtensionDescription = do
 
 encodeExtensionDescription :: ExtensionDescription -> B.ByteString
 encodeExtensionDescription ExtensionDescription {..} =
-    extName <> mconcat (map encodeParam extParams)
+    mconcat (extName : map encodeParam extParams)
   where
-    encodeParam (key, Nothing)  = ";" <> key
-    encodeParam (key, Just val) = ";" <> key <> "=" <> val
+    encodeParam (key, Nothing)  = ";" `mappend` key
+    encodeParam (key, Just val) = ";" `mappend` key `mappend` "=" `mappend` val
 
 type ExtensionDescriptions = [ExtensionDescription]
 

--- a/tests/haskell/Network/WebSockets/Tests.hs
+++ b/tests/haskell/Network/WebSockets/Tests.hs
@@ -16,6 +16,7 @@ import           Data.Binary.Get                       (runGetOrFail)
 import qualified Data.ByteString.Lazy                  as BL
 import           Data.List                             (intersperse)
 import           Data.Maybe                            (catMaybes)
+import           Data.Monoid                           (mempty, mconcat)
 import           Network.WebSockets
 import qualified Network.WebSockets.Hybi13             as Hybi13
 import           Network.WebSockets.Hybi13.Demultiplex

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -80,7 +80,7 @@ Library
 
   Build-depends:
     attoparsec        >= 0.10   && < 0.14,
-    base              >= 4.4    && < 5,
+    base              >= 4.6    && < 5,
     base64-bytestring >= 0.1    && < 1.1,
     binary            >= 0.8.1  && < 0.10,
     blaze-builder     >= 0.3    && < 0.5,


### PR DESCRIPTION
The use of `Data.IORef.atomicModifyIORef'` requires
a lower bound on `base` of `>= 4.6`.