### PR TITLE
relax upper bound for streaming-commons

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 - UNRELEASED
     * Remove `blaze-builder` dependency
+    * Relax `streaming-commons` dependency upper bound to < 0.3
+
 
 - 0.12.3.1 (2018-01-10)
     * Bump CHANGELOG with IPv6 warning

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -90,7 +90,7 @@ Library
     network           >= 2.3    && < 2.7,
     random            >= 1.0    && < 1.2,
     SHA               >= 1.5    && < 1.7,
-    streaming-commons >= 0.1    && < 0.2,
+    streaming-commons >= 0.1    && < 0.3,
     text              >= 0.10   && < 1.3,
     entropy           >= 0.2.1  && < 0.5
 
@@ -147,7 +147,7 @@ Test-suite websockets-tests
     network           >= 2.3    && < 2.7,
     random            >= 1.0    && < 1.2,
     SHA               >= 1.5    && < 1.7,
-    streaming-commons >= 0.1    && < 0.2,
+    streaming-commons >= 0.1    && < 0.3,
     text              >= 0.10   && < 1.3,
     entropy           >= 0.2.1  && < 0.5
 


### PR DESCRIPTION
This allows for recent version(s) of `streaming-commons` that have dropped the dependency on `blaze-builder`.