### PR TITLE
Fix build with GHC 7.6 and 7.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+- UNRELEASED
+    * Fix build with GHC 7.6 and 7.8
+
 - 0.12.5.0 (2018-06-01)
     * Add `newClientConnection` (by Renzo Carbonara)
 

--- a/src/Network/WebSockets/Client.hs
+++ b/src/Network/WebSockets/Client.hs
@@ -131,7 +131,7 @@ newClientConnection stream host path opts customHeaders = do
     write   <- encodeMessages protocol ClientConnection stream
     sentRef <- newIORef False
 
-    pure $ Connection
+    return $ Connection
         { connectionOptions   = opts
         , connectionType      = ClientConnection
         , connectionProtocol  = protocol


### PR DESCRIPTION
And could you please deprecate the 0.12.5.0 release?

It would also be great if CI could cover these GHC versions.