### PR TITLE
Implement more fine-grained construction of client Connection

### DIFF
--- a/websockets.cabal
+++ b/websockets.cabal
@@ -59,13 +59,13 @@ Library
 
   Exposed-modules:
     Network.WebSockets
+    Network.WebSockets.Client
     Network.WebSockets.Connection
     Network.WebSockets.Extensions
     Network.WebSockets.Stream
     -- Network.WebSockets.Util.PubSub TODO
 
   Other-modules:
-    Network.WebSockets.Client
     Network.WebSockets.Connection.Options
     Network.WebSockets.Extensions.Description
     Network.WebSockets.Extensions.PermessageDeflate


### PR DESCRIPTION
I'm using [hspec-wai](https://hackage.haskell.org/package/hspec-wai) to test my HTTP APIs and would like to be able to also test my websocket end points in the same test-suite. 

The idea of hspec-wai is that the test suit runs the WAI handlers directly instead of communicating with them through a web server. This means that requests are not serialized into wire format. However, in the case of wai-websockets, the _response_ is a pair of serialized octet-streams. These streams are easily adapted to websocket's `stream` type, but there is no function that accepts either a half- or a completely negotiated websocket connection. 

To allow for this I've factored out `mkConnection` and `checkServerResponse` from `newClientConnection` and also exported `createRequest`, `Protocol(..)` and `defaultProtocol` from `Network.WebSocket.Client` as well as added the module to Exported-modules. 

