### PR TITLE
Close the underlying tcp connection when rejecting

### DIFF
--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -12,6 +12,7 @@ module Network.WebSockets.Connection
     , RejectRequest(..)
     , defaultRejectRequest
     , rejectRequestWith
+    , rejectRequestAndCloseWith
 
     , Connection (..)
 
@@ -245,6 +246,16 @@ rejectRequest
 rejectRequest pc body = rejectRequestWith pc
     defaultRejectRequest {rejectBody = body}
 
+--------------------------------------------------------------------------------
+
+-- | Send a rejection message to the client and close the underlying connection
+rejectRequestAndCloseWith
+    :: PendingConnection -- ^ Connection to reject and close
+    -> RejectRequest -- ^ Params on how to reject the request
+    -> IO ()
+rejectRequestAndCloseWith pc reject = do
+  rejectRequestWith pc reject
+  Stream.close $ pendingStream pc
 
 --------------------------------------------------------------------------------
 data Connection = Connection


### PR DESCRIPTION
When using this library in conjunction with `servant-websockets`, we noticed that after rejecting the request, the connection was held open until it timed out, approximately one minute later. Our current workaround is to accept the connect and then immediately `sendClose` and exit. 

This adds `rejectAndCloseWith` to reject the request and close the underlying tcp connection immediately to avoid the workaround above.