### PR TITLE
Expose Connection constructor

### DIFF
--- a/src/Network/WebSockets.hs
+++ b/src/Network/WebSockets.hs
@@ -14,7 +14,7 @@ module Network.WebSockets
     , rejectRequestWith
 
       -- * Main connection type
-    , Connection
+    , Connection(..)
 
       -- * Options for connections
     , ConnectionOptions (..)

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -63,6 +63,7 @@ Library
     Network.WebSockets.Client
     Network.WebSockets.Connection
     Network.WebSockets.Extensions
+    Network.WebSockets.Http
     Network.WebSockets.Stream
     -- Network.WebSockets.Util.PubSub TODO
 
@@ -71,7 +72,6 @@ Library
     Network.WebSockets.Extensions.Description
     Network.WebSockets.Extensions.PermessageDeflate
     Network.WebSockets.Extensions.StrictUnicode
-    Network.WebSockets.Http
     Network.WebSockets.Hybi13
     Network.WebSockets.Hybi13.Demultiplex
     Network.WebSockets.Hybi13.Mask


### PR DESCRIPTION
I'd like to access the [connectionSentClose](https://github.com/jaspervdj/websockets/blob/248228827b5f0a72920bd78637ce1f1514be1a8a/src/Network/WebSockets/Connection.hs#L256) field of the `Connection` object, so I can manually send a close message when one hasn't been sent yet. This PR exposes the fields.