### PR TITLE
Added a way to manually send a Pong message.

### DIFF
--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -31,6 +31,7 @@ module Network.WebSockets.Connection
     , sendClose
     , sendCloseCode
     , sendPing
+    , sendPong
 
     , withPingThread
     , forkPingThread
@@ -388,6 +389,10 @@ sendCloseCode conn code =
 sendPing :: WebSocketsData a => Connection -> a -> IO ()
 sendPing conn = send conn . ControlMessage . Ping . toLazyByteString
 
+--------------------------------------------------------------------------------
+-- | Send a pong
+sendPong :: WebSocketsData a => Connection -> a -> IO ()
+sendPong conn = send conn . ControlMessage . Pong . toLazyByteString
 
 --------------------------------------------------------------------------------
 -- | Forks a ping thread, sending a ping message every @n@ seconds over the


### PR DESCRIPTION
Hi! I've been playing around with various cryptocurrency exchange APIs using this library (+wuss) and I'm loving it so far. However, I've come across an unusual situation. There are certain servers that seem to expect unsolicited Pongs (?!) to keep the connection alive. So I've added a way to manually send the Pong messages. It's a fairly small addition - basically identical to the sendPing function. Hope you can merge. Let me know if I need to add anything else.

Thanks! 