### PR TITLE
Allow text-2.0

### DIFF
--- a/websockets.cabal
+++ b/websockets.cabal
@@ -94,7 +94,7 @@ Library
     random            >= 1.0    && < 1.3,
     SHA               >= 1.5    && < 1.7,
     streaming-commons >= 0.1    && < 0.3,
-    text              >= 0.10   && < 1.3,
+    text              >= 0.10   && < 2.1,
     entropy           >= 0.2.1  && < 0.5
 
 Test-suite websockets-tests
@@ -154,7 +154,7 @@ Test-suite websockets-tests
     random            >= 1.0    && < 1.3,
     SHA               >= 1.5    && < 1.7,
     streaming-commons >= 0.1    && < 0.3,
-    text              >= 0.10   && < 1.3,
+    text              >= 0.10   && < 2.1,
     entropy           >= 0.2.1  && < 0.5
 
 Executable websockets-example
@@ -182,7 +182,7 @@ Executable websockets-example
     network           >= 2.3    && < 3.2,
     random            >= 1.0    && < 1.3,
     SHA               >= 1.5    && < 1.7,
-    text              >= 0.10   && < 1.3,
+    text              >= 0.10   && < 2.1,
     entropy           >= 0.2.1  && < 0.5
 
 Executable websockets-autobahn
@@ -213,7 +213,7 @@ Executable websockets-autobahn
     network           >= 2.3    && < 3.2,
     random            >= 1.0    && < 1.3,
     SHA               >= 1.5    && < 1.7,
-    text              >= 0.10   && < 1.3,
+    text              >= 0.10   && < 2.1,
     entropy           >= 0.2.1  && < 0.5
 
 Benchmark bench-mask
@@ -242,5 +242,5 @@ Benchmark bench-mask
     network           >= 2.3    && < 3.2,
     random            >= 1.0    && < 1.3,
     SHA               >= 1.5    && < 1.7,
-    text              >= 0.10   && < 1.3,
+    text              >= 0.10   && < 2.1,
     entropy           >= 0.2.1  && < 0.5


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2.0'

NOTE: The failing CI doesn't look like it is because of this PR. It seems to be because Stack metadata moved servers.