### PR TITLE
Use GHC 9.0 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: 'haskell:8.6'
+      - image: 'haskell:9.0'
 
     steps:
       - checkout
@@ -22,14 +22,19 @@ jobs:
           name: 'Install virtualenv for autobahn'
           command: 'apt-get update && apt-get install --yes virtualenv python2.7-dev'
       - run:
-          name: 'Install and test'
-          command: 'stack --no-terminal --copy-bins test --pedantic'
+          name: 'Update package index'
+          command: 'cabal update'
+      - run:
+          name: 'Build'
+          command: 'cabal build --enable-tests -f Example all'
+      - run:
+          name: 'Test'
+          command: 'cabal test'
       - run:
           name: 'Run autobahn tests'
           command: 'bash tests/autobahn/autobahn.sh'
       - save_cache:
           key: 'v1-websockets-{{ arch }}-{{ .Branch }}-{{ .Revision }}'
           paths:
-            - '~/.stack'
             - '~/.virtualenvs'
-            - '.stack-work'
+            - 'dist-newstyle'

--- a/tests/autobahn/autobahn.sh
+++ b/tests/autobahn/autobahn.sh
@@ -17,7 +17,9 @@ else
 fi
 
 echo "Launching websockets server in background..."
-(stack exec websockets-autobahn) & WEBSOCKETS_AUTOBAHN_PID="$!"
+(cabal run websockets-autobahn -f Example) & WEBSOCKETS_AUTOBAHN_PID="$!"
+
+sleep 10
 
 echo "Getting config..."
 cp tests/autobahn/fuzzingclient.json .


### PR DESCRIPTION
Stack was not managing to get a GHC running, even with the `--system-ghc` flag. So I switched the project to `cabal-install`.

The test suite results for this PR can be seen at https://app.circleci.com/pipelines/github/ysangkok/websockets?branch=ghc-9.0-in-ci&filter=all