### PR TITLE
Require random >= 1.0.1

### DIFF
--- a/websockets.cabal
+++ b/websockets.cabal
@@ -96,7 +96,7 @@ Library
     clock             >= 0.8    && < 0.9,
     containers        >= 0.3    && < 0.7,
     network           >= 2.3    && < 3.2,
-    random            >= 1.0    && < 1.3,
+    random            >= 1.0.1  && < 1.3,
     SHA               >= 1.5    && < 1.7,
     streaming-commons >= 0.1    && < 0.3,
     text              >= 0.10   && < 2.1,


### PR DESCRIPTION
`instance Random Word32` is not available in `random-1.0.0.*`.

As a Hackage trustee I made revisions:
https://hackage.haskell.org/package/websockets-0.12.7.2/revisions/
https://hackage.haskell.org/package/websockets-0.12.7.3/revisions/