### PR TITLE
add client-example executable

### DIFF
--- a/websockets.cabal
+++ b/websockets.cabal
@@ -162,7 +162,7 @@ Test-suite websockets-tests
     text              >= 0.10   && < 2.2,
     entropy           >= 0.2.1  && < 0.5
 
-Executable websockets-example
+Executable websockets-server-example
   If !flag(Example)
     Buildable: False
 
@@ -172,23 +172,26 @@ Executable websockets-example
   Default-language: Haskell2010
 
   Build-depends:
+    base,
     websockets,
-    -- Copied from regular dependencies...
-    async             >= 2.2    && < 2.3,
-    attoparsec        >= 0.10   && < 0.15,
-    base              >= 4      && < 5,
-    base64-bytestring >= 0.1    && < 1.3,
-    binary            >= 0.8.1  && < 0.11,
-    bytestring        >= 0.9    && < 0.12,
-    bytestring-builder             < 0.11,
-    case-insensitive  >= 0.3    && < 1.3,
-    clock             >= 0.8    && < 0.9,
-    containers        >= 0.3    && < 0.7,
-    network           >= 2.3    && < 3.2,
-    random            >= 1.0    && < 1.3,
-    SHA               >= 1.5    && < 1.7,
-    text              >= 0.10   && < 2.2,
-    entropy           >= 0.2.1  && < 0.5
+    text
+
+Executable websockets-client-example
+  If !flag(Example)
+    Buildable: False
+
+  Hs-source-dirs:   example
+  Main-is:          client.hs
+  Ghc-options:      -Wall
+  Default-language: Haskell2010
+
+  Build-depends:
+    base,
+    websockets,
+    text,
+    network,
+    mtl
+
 
 Executable websockets-autobahn
   If !flag(Example)


### PR DESCRIPTION
I've removed a bunch of dependencies for examples that aren't needed and removed the bounds (as they are already enforced in the library itself and not used beyond the simple type imports).