### PR TITLE
Add Renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,21 @@
+{
+  "$schema": 'https://docs.renovatebot.com/renovate-schema.json',
+  "enabledManagers": ['custom.jsonata', 'haskell-cabal'],
+  "customManagers":
+    {
+      "customType": 'jsonata',
+      "fileFormat": 'yaml',
+      "fileMatch": ['stack.yaml$'],
+      "datasourceTemplate": 'hackage',
+      "versioningTemplate": 'loose',
+      "matchStrings": ['\
+          $map($."extra-deps", function ($depLine) { \n\
+            (function ($strArray) { \n\
+                {"depName": $strArray[0] \n\
+                  , "currentValue":  $strArray[1] \n\
+                } \n\
+            })($split($depLine, "-")) \n\
+          }) \n\
+      ']
+    }
+}


### PR DESCRIPTION
I noticed that @domenkozar was [interested in automated updates](https://github.com/dependabot/dependabot-core/issues/2745#issuecomment-1216338920).
I am looking for a real-world repo to showcase `stack.yaml` support for.

So I thought I would submit this here since there seems to be interest.

This PR should work as submitted after setting up [the Github app](https://github.com/apps/renovate).

For local testing, the following configuration options need to be added:

```
, "onboarding": false
, "token": "<secret github token>"
, "repositories": [{ repository: 'yourGithubUser/websockets' }]
, "platform": "github"
```

Renovate can then be executed locally using:

```
docker run --mount type=bind,src=$PWD,dst=/mount-point,ro \
  -e RENOVATE_REQUIRE_CONFIG=ignored \
  -e RENOVATE_CONFIG_FILE=/mount-point/renovate.json5 \
  -e LOG_LEVEL=debug \
  renovate/renovate
```

The advantage of this setup, which loads the configuration from your local
filesystem, is that you can iterate without making repo changes.
