### PR TITLE
random 1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,12 @@ jobs:
         run: cabal haddock all
 
       - name: Install virtualenv
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
+          # python2.7-dev is not available on ubuntu-24.04 (or larger, I suppose)
         run: |
           sudo apt-get install --yes virtualenv python2.7-dev
           pip install virtualenv
 
       - name: Run autobahn tests
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: bash tests/autobahn/autobahn.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc-version: ['9.8', '9.6', '9.4', '9.2', '9.0']
+        ghc-version: ['9.12', '9.10', '9.8', '9.6', '9.4', '9.2']
 
         include:
           - os: windows-latest
-            ghc-version: '9.8'
+            ghc-version: '9.12'
           - os: macos-latest
-            ghc-version: '9.8'
+            ghc-version: '9.12'
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         # The last step generates dist-newstyle/cache/plan.json for the cache key.
 
       - name: Restore cached dependencies
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: cache
         env:
           key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
@@ -55,7 +55,7 @@ jobs:
 
       # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
       - name: Save cached dependencies
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         # If we had an exact cache hit, trying to save the cache would error because of key clash.
         if: steps.cache.outputs.cache-hit != 'true'
         with:
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install virtualenv
         if: matrix.os == 'ubuntu-latest'
-        run: | 
+        run: |
           sudo apt-get install --yes virtualenv python2.7-dev
           pip install virtualenv
 

--- a/websockets.cabal
+++ b/websockets.cabal
@@ -95,7 +95,7 @@ Library
     case-insensitive  >= 0.3    && < 1.3,
     containers        >= 0.3    && < 0.8,
     network           >= 2.3    && < 3.3,
-    random            >= 1.0.1  && < 1.3,
+    random            >= 1.0.1  && < 1.4,
     SHA               >= 1.5    && < 1.7,
     streaming-commons >= 0.1    && < 0.3,
     text              >= 0.10   && < 2.2,
@@ -140,7 +140,7 @@ Test-suite websockets-tests
 
   Build-depends:
     HUnit                      >= 1.2 && < 1.7,
-    QuickCheck                 >= 2.7 && < 2.15,
+    QuickCheck                 >= 2.7 && < 2.16,
     test-framework             >= 0.4 && < 0.9,
     test-framework-hunit       >= 0.2 && < 0.4,
     test-framework-quickcheck2 >= 0.2 && < 0.4,
@@ -154,7 +154,7 @@ Test-suite websockets-tests
     case-insensitive  >= 0.3    && < 1.3,
     containers        >= 0.3    && < 0.8,
     network           >= 2.3    && < 3.3,
-    random            >= 1.0    && < 1.3,
+    random            >= 1.0    && < 1.4,
     SHA               >= 1.5    && < 1.7,
     streaming-commons >= 0.1    && < 0.3,
     text              >= 0.10   && < 2.2,
@@ -207,14 +207,14 @@ Executable websockets-autobahn
     -- Copied from regular dependencies...
     async             >= 2.2    && < 2.3,
     attoparsec        >= 0.10   && < 0.15,
-    base              >= 4.14     && < 5,
+    base              >= 4.14   && < 5,
     base64-bytestring >= 0.1    && < 1.3,
     binary            >= 0.8.1  && < 0.11,
     bytestring        >= 0.9    && < 0.13,
     case-insensitive  >= 0.3    && < 1.3,
     containers        >= 0.3    && < 0.8,
     network           >= 2.3    && < 3.3,
-    random            >= 1.0    && < 1.3,
+    random            >= 1.0    && < 1.4,
     SHA               >= 1.5    && < 1.7,
     text              >= 0.10   && < 2.2,
     entropy           >= 0.2.1  && < 0.5
@@ -241,7 +241,7 @@ Benchmark bench-mask
     case-insensitive  >= 0.3    && < 1.3,
     containers        >= 0.3    && < 0.8,
     network           >= 2.3    && < 3.3,
-    random            >= 1.0    && < 1.3,
+    random            >= 1.0    && < 1.4,
     SHA               >= 1.5    && < 1.7,
     text              >= 0.10   && < 2.2,
     entropy           >= 0.2.1  && < 0.5


### PR DESCRIPTION
Closes #257.

Commits:
- **Bump CI to GHC 9.12 - 9.2**
- **Bump to random<1.4 and QuickCheck<2.16**

CI running here: https://github.com/andreasabel/websockets/actions
And it does use random-1.3: https://github.com/andreasabel/websockets/actions/runs/15388497688/job/43292375912#step:4:65
and QuickCheck-2.15: https://github.com/andreasabel/websockets/actions/runs/15388497688/job/43292375912#step:4:76