### PR TITLE
Document that rejectRequestWith requires closing the stream

### DIFF
--- a/src/Network/WebSockets/Connection.hs
+++ b/src/Network/WebSockets/Connection.hs
@@ -227,6 +227,7 @@ defaultRejectRequest = RejectRequest
 
 
 --------------------------------------------------------------------------------
+-- | Requires calling 'pendingStream' and 'Stream.close'.
 rejectRequestWith
     :: PendingConnection  -- ^ Connection to reject
     -> RejectRequest      -- ^ Params on how to reject the request


### PR DESCRIPTION
I just ran into the same issue described in [#211](https://github.com/jaspervdj/websockets/pull/211). In my case I had noticed the note about calling `Stream.close` in the `rejectRequest` docs but I didn't realize that the disclaimer applied to `rejectRequestWith` as well. Based on [this comment](https://github.com/jaspervdj/websockets/pull/211#issuecomment-1872473980) maybe it makes sense to close the underlying stream when rejecting the request, but short of that maybe this note will help someone else avoid the same issue.
